### PR TITLE
fix: TimeOut-Problem bei Mitglieder-Start-Button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,11 +28,11 @@ group :assets, :production, 'testing-aki' do
 
 end
 
-# See https://github.com/sstephenson/execjs#readme for more 
+# See https://github.com/sstephenson/execjs#readme for more
 # supported runtimes.
 # This is also needed by twitter-bootstrap-rails in production.
 gem 'execjs'
-# But therubyracer apparently uses a lot of memory: 
+# But therubyracer apparently uses a lot of memory:
 # https://github.com/seyhunak/twitter-bootstrap-rails/issues/336
 gem 'therubyracer', :platform => :ruby
 
@@ -56,15 +56,15 @@ gem 'nokogiri'								# MIT License
 #   gem 'gmaps4rails', '>= 2.0.0.pre', git: 'https://github.com/fiedl/Google-Maps-for-Rails.git'
 
 # jQuery UI
-gem 'jquery-ui-rails'							# dual: MIT License, GPL2 License 
+gem 'jquery-ui-rails'							# dual: MIT License, GPL2 License
 
 # DAG für Nodes Model, see: https://github.com/resgraph/acts-as-dag
 #gem 'acts-as-dag', path: '../acts-as-dag'
 #gem 'acts-as-dag', git: "git://github.com/resgraph/acts-as-dag.git"	# MIT License
 #gem 'acts-as-dag', '>= 2.5.7'  # now in your_platform
 
-# Formtastic Form Helper, 
-# see: https://github.com/justinfrench/formtastic, 
+# Formtastic Form Helper,
+# see: https://github.com/justinfrench/formtastic,
 # http://rubydoc.info/gems/formtastic/frames
 gem 'formtastic'							# MIT License
 
@@ -74,7 +74,7 @@ gem 'json'								# Ruby License
 # Lucene
 # gem 'lucene'								# MIT License
 
-# Farbiger Konsolen-Output					
+# Farbiger Konsolen-Output
 gem 'colored'								# MIT License
 
 # Auto Completion
@@ -86,15 +86,15 @@ group :development do
   gem 'capistrano' #, '~>2.11.2'
   gem 'capistrano_colors'
   gem 'net-ssh', '2.4.0'
-end 
+end
 
 # Debug Tools
 group :development do
 
   # debugger: http://guides.rubyonrails.org/debugging_rails_applications.html
-  #gem 'debugger'                   
+  #gem 'debugger'
 
-  gem 'better_errors'              # see Railscasts #402               
+  gem 'better_errors'              # see Railscasts #402
   gem 'binding_of_caller'
   gem 'meta_request'
 end
@@ -136,7 +136,7 @@ end
 #  end
 #  if RUBY_PLATFORM.downcase.include?("darwin") # Mac
 #    gem 'rb-fsevent', :require => false
-#    gem 'growl'      
+#    gem 'growl'
 #  end
 #  if RUBY_PLATFORM.downcase.include?("windows")
 #   gem 'rb-fchange'
@@ -178,7 +178,9 @@ gem 'mercury-rails', git: 'git://github.com/jejacks0n/mercury'
 
 # readline (for rails console)
 # see https://github.com/luislavena/rb-readline/issues/84#issuecomment-17335885
-#gem 'rb-readline', '~> 0.5.0', group: :development, require: 'readline' 
+#gem 'rb-readline', '~> 0.5.0', group: :development, require: 'readline'
 
 gem 'gmaps4rails', '~> 2.0.1', git: 'git@github.com:fiedl/Google-Maps-for-Rails.git'
 
+# To customly set timeout time we need rack-timeout
+gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack-timeout (0.0.4)
     rails (3.2.13)
       actionmailer (= 3.2.13)
       actionpack (= 3.2.13)
@@ -397,6 +398,7 @@ DEPENDENCIES
   passgen
   poltergeist (= 1.1.2)
   pry
+  rack-timeout
   rails (~> 3.2.11)
   rb-inotify (~> 0.9)
   rspec-rails (= 2.10.0)

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
+require "rack-timeout"
+use Rack::Timeout
+Rack::Timeout.timeout = 120
+
 require ::File.expand_path('../config/environment',  __FILE__)
 run Wingolfsplattform::Application
+

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Wingolfsplattform::Application.configure do
 
   # Load Secret Settings
   # -> moved to config/application.rb
-    
+
   # SMTP Settings
   config.action_mailer.delivery_method = :smtp
 
@@ -80,7 +80,7 @@ Wingolfsplattform::Application.configure do
       in config/secrets.yml.
     "
   end
-  
+
   config.action_mailer.smtp_settings = {
     address: 'smtp.1und1.de',
     user_name: 'wingolfsplattform@wingolf.org',
@@ -88,8 +88,8 @@ Wingolfsplattform::Application.configure do
     domain: 'wingolfsplattform.org',
     enable_starttls_auto: true,
     # only if certificate malfunctions:
-    # openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE    
+    # openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
   }
-  config.action_mailer.default_url_options = { host: 'wingolfsplattform.org', protocol: 'http' }
+  config.action_mailer.default_url_options = { host: 'wingolfsplattform.org', protocol: 'https' }
 
 end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,2 @@
+# config/initializers/timeout.rb
+Rack::Timeout.timeout = 120  # seconds

--- a/vendor/engines/your_platform/app/controllers/pages_controller.rb
+++ b/vendor/engines/your_platform/app/controllers/pages_controller.rb
@@ -11,7 +11,7 @@ class PagesController < ApplicationController
       end
 
       @blog_entries = @page.blog_entries.limit(10)
-      
+
       @title = @page.title
       @navable = @page
       @page = @page.becomes(Page)  # rather than BlogPost etc.

--- a/vendor/engines/your_platform/spec/features/page_spec.rb
+++ b/vendor/engines/your_platform/spec/features/page_spec.rb
@@ -11,4 +11,10 @@ feature "Viewing a Page" do
     visit page_path(@page)
     page.should have_content "My Shiny Page"
   end
+  scenario "Visiting the page 'My Shiny Page' and afterwards the page 'Intranet Root'" do
+    visit page_path(@page)
+    click_on("Intranet")
+    page_title = page.all('title', :text => "Intranet - Wingolfsplattform")
+    page_title.class.to_s.should == "Capybara::Result"
+  end
 end


### PR DESCRIPTION
- Zum einen wird der TimeOut per Rack auf 120 Sekunden hochgestellt.
- Zum anderen wird das Protokoll für Link-Erzeugung von http auf https umgestellt, sodass wir nicht zwischen https und http hin und her springen.
