### PR TITLE
hide buttons 'delete user account' and 'send new password' for nonadmins

### DIFF
--- a/app/views/user_accounts/_user_account.html.haml
+++ b/app/views/user_accounts/_user_account.html.haml
@@ -16,9 +16,10 @@
               = best_in_place @user, attribute.to_sym
 .show_only_in_edit_mode
   %dl
-    %dt
-      = t('password') + ':'
-    %dd
-      = button_to t(:send_new_password), forgot_password_user_path(@user.id), method: :put, :class => 'btn btn-success'
+    - if can? :manage, @user
+      %dt
+        = t('password') + ':'
+      %dd
+        = button_to t(:send_new_password), forgot_password_user_path(@user.id), method: :put, :class => 'btn btn-success'
 
-  = button_to t(:delete_account), user_account_path(@user.account.id), :method => :delete, :class => 'btn btn-danger'
+      = button_to t(:delete_account), user_account_path(@user.account.id), :method => :delete, :class => 'btn btn-danger'


### PR DESCRIPTION
Dieser Pull-Request passt den Benutzer-Profil-View der Rechteverwaltung `cancan` entsprechend an, sodass die genannten Buttons nur dann angezeigt werden, wenn der Benutzer auch das Recht hat die entsprechende Funktion auszuführen.
