### PR TITLE
Task to cache the Aktivitätszahl for all users

### DIFF
--- a/lib/tasks/cache_users.rake
+++ b/lib/tasks/cache_users.rake
@@ -1,0 +1,23 @@
+namespace :cache do
+  require 'colored'
+
+  desc "For all users call the cached methods to load the value in the cache"
+  task users: :environment do
+    require File.join(Rails.root, 'app/models/user')
+    require File.join(Rails.root, 'vendor/engines/your_platform/app/models/user')
+
+    print "\nFor all users call the cached methods to load the value in the cache.\n".cyan
+    puts "There are #{User.count} users in total now."
+
+    User.all.each do |user|
+      print ".".yellow
+      user.cached_aktivitaetszahl
+      #user.cached_last_group_in_first_corporation
+      print ".".green
+    end
+   
+    puts ""
+    puts "The cache is filled."
+
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -12,7 +12,8 @@ namespace :import do
       'import:external_corporations',
       'import:standard_workflows',
       'import:group_profiles',
-      'import:users'
+      'import:users',
+      'cache:users'
     ]
 
     


### PR DESCRIPTION
My intension:
I wanted to have the cache filled during the import so that it is already functional after import.

My changes:
1. I introduced a new task which is called during import.
2. This task fills the cache for all users.

The effect:
The first time, a user logs in, the page is loaded faster. 
