### PR TITLE
Load big groups

### DIFF
--- a/vendor/engines/your_platform/app/controllers/groups_controller.rb
+++ b/vendor/engines/your_platform/app/controllers/groups_controller.rb
@@ -73,11 +73,15 @@ class GroupsController < ApplicationController
   # https://github.com/apneadiving/Google-Maps-for-Rails/wiki/Controller
   #
   def map_address_fields
-    user_ids = @group.descendant_users.collect { |user| user.id }
-    user_address_fields = ProfileField.where( type: "ProfileFieldTypes::Address", profileable_type: "User", profileable_id: user_ids )
-    group_ids = ([@group] + @group.descendant_groups).collect { |group| group.id }
-    group_address_fields = ProfileField.where( type: "ProfileFieldTypes::Address", profileable_type: "Group", profileable_id: group_ids )
-    (user_address_fields + group_address_fields)
+    if (@group.descendant_users.count<260)
+      user_ids = @group.descendant_users.collect { |user| user.id }
+      user_address_fields = ProfileField.where( type: "ProfileFieldTypes::Address", profileable_type: "User", profileable_id: user_ids )
+      group_ids = ([@group] + @group.descendant_groups).collect { |group| group.id }
+      group_address_fields = ProfileField.where( type: "ProfileFieldTypes::Address", profileable_type: "Group", profileable_id: group_ids )
+      (user_address_fields + group_address_fields)
+    else
+      []
+    end
   end
 
 end

--- a/vendor/engines/your_platform/app/views/user_group_memberships/_list_item.html.haml
+++ b/vendor/engines/your_platform/app/views/user_group_memberships/_list_item.html.haml
@@ -1,7 +1,4 @@
--# locals: user_group_membership, user, group
-- user_group_membership ||= UserGroupMembership.find_by( user: user, group: group )
-- user ||= user_group_membership.user
-- group ||= user_group_membership.group
+-# locals: user, group
 %li
   = link_to user.title, user
   - if can? :manage, user


### PR DESCRIPTION
My intension:
I wanted to make the big groups loadable.
The groups "Jeder", "Korporationen" failed to load. 

My changes:
1. For groups with more than 260 descendant users, the google map is not filled.
2. for each displayed member in the member list, 1 SQL statement less is executed

The effect:
After rails server restart the loading times are slightly higher than the second time. 
"Jeder" can be loaded in 18 respective 4 seconds.
"Korporationen" can be loaded in 7 respective 5 seconds.
