### PR TITLE
Blättern mit lokalisierten Texten

### DIFF
--- a/vendor/engines/your_platform/config/locales/pagination/de.yml
+++ b/vendor/engines/your_platform/config/locales/pagination/de.yml
@@ -1,0 +1,6 @@
+de:
+  will_paginate:
+    previous_label: Vorige Seite
+    page_gap: ...
+    next_label: Nächste Seite
+

--- a/vendor/engines/your_platform/config/locales/pagination/en.yml
+++ b/vendor/engines/your_platform/config/locales/pagination/en.yml
@@ -1,0 +1,5 @@
+en:
+  will_paginate:
+    previous_label: Previous page
+    page_gap: ...
+    next_label: Next page


### PR DESCRIPTION
Auf einer Gruppenseite mit vielen Mitgliedern werden von diesen 25 auf einmal angezeigt. Die weiteren können über Navigation erreicht werden. die Navigation ist nun deutsch und englisch beschriftet.
