### PR TITLE
Cache corporate vita of a user

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -37,7 +37,7 @@
   %h1.section.corporate_vita= t :corporate_vita
   %div
     = render partial: 'workflow_triggers'
-    = corporate_vita_for_user @user
+    = cached_corporate_vita_for_user @user
 
 - # Groups Box
 %h1= t(:groups_of) + " " + @user.first_name

--- a/vendor/engines/your_platform/app/helpers/corporate_vita_helper.rb
+++ b/vendor/engines/your_platform/app/helpers/corporate_vita_helper.rb
@@ -1,5 +1,11 @@
 module CorporateVitaHelper
 
+  def cached_corporate_vita_for_user( user)
+    if user
+      Rails.cache.fetch([user, "corporate_vita_for_user"]) { corporate_vita_for_user( user ) }
+    end
+  end
+
   def corporate_vita_for_user( user )
     render partial: 'users/corporate_vita', locals: { 
       user: @user,

--- a/vendor/engines/your_platform/app/models/user_group_membership.rb
+++ b/vendor/engines/your_platform/app/models/user_group_membership.rb
@@ -45,6 +45,7 @@ class UserGroupMembership < DagLink
 
   def flush_cache
     Rails.cache.delete([self.user, "my_groups_table"])
+    Rails.cache.delete([self.user, "corporate_vita_for_user"])
     Rails.cache.delete([self.user, "last_group_in_first_corporation"])
     Rails.cache.delete([self.user, "aktivitaetszahl"])  # TODO: Move to wingolfsplattform!
   end


### PR DESCRIPTION
The corporate vita is cached on a high level. 
The rendering result is cached, hence currently this cache cannot be filled by a task.
The cache is cleared as soon as something in the user's UserGroupMembership is commited or destroyed.
