### PR TITLE
Profile fields like phone&email remain changed and formatted

### DIFF
--- a/app/controllers/profile_fields_controller.rb
+++ b/app/controllers/profile_fields_controller.rb
@@ -14,9 +14,10 @@ class ProfileFieldsController < ApplicationController
       format.js
     end
   end
-  
+
   def update
-    respond_with @profile_field.update_attributes(params[:profile_field])
+    @profile_field.update_attributes(params[:profile_field])
+    respond_with_bip @profile_field
   end
   
   def destroy

--- a/vendor/engines/your_platform/app/assets/javascripts/controllers-ng/profile_angular.js.coffee
+++ b/vendor/engines/your_platform/app/assets/javascripts/controllers-ng/profile_angular.js.coffee
@@ -133,6 +133,7 @@
     $scope.save() if newState == false
   )
   $scope.$on( 'clickOutside', ->
+    $scope.editMode = false
     $scope.save() if not $scope.editMode
   )
   $scope.edit = ->

--- a/vendor/engines/your_platform/app/helpers/profile_field_helper.rb
+++ b/vendor/engines/your_platform/app/helpers/profile_field_helper.rb
@@ -32,7 +32,7 @@ module ProfileFieldHelper
                       :section => args[:profile_section],
                       :label => label_in_english_with_underscores
                     ),
-             :id => "add_#{args[:profile_field_type].demodulize.underscore}_field",
+             :id => "add_#{label_in_english_with_underscores}_field",
              :remote => true,
              :method => 'post'
            )


### PR DESCRIPTION
Observed behavior:
- After switching from edit to display for Contact Information fields, like email and website the fields were no longer formatted
- After leaving the edit, the changed values were displayed and stored in database, but switching to edit again, showed the old values. Which were even stored after closing it again.

Fixes:
1. The Controller provides a response which informs also the best_in_place, so that it switches back to display mode
2. The click outside the box switches back to display mode
3.  Use a local variable instead of recomputing a value

New behavior
- after switching from edit to display, it takes a few seconds and the values are shown pretty again
- after switching from edit to display to edit, the new values are shown 
