### PR TITLE
Allow multiple memberships between user and group

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,24 @@ class User
     bv_membership.valid_from if bv
   end
     
+  # Groups
+  # ------------------------------------------------------------------------------------------
+  # Override the add_to_group_if_requested method in order to add to Hospitanten
+  #
+  alias_method :orig_add_to_group_if_requested, :add_to_group_if_requested
+  def add_to_group_if_requested
+    self.orig_add_to_group_if_requested
+    unless self.add_to_corporation.blank?
+      corporation = add_to_corporation if add_to_corporation.kind_of? Group
+      corporation ||= Group.find( add_to_corporation ) if add_to_corporation.to_i
+      add_to_corporation = nil
+      if corporation
+        hospitanten_group = corporation.descendant_groups.where(name: "Hospitanten").first
+        hospitanten_group.assign_user self
+      end
+    end
+  end
+
 
   # This method returns the aktivitaetszahl of the user, e.g. "E10 H12".
   #

--- a/app/models/user_group_membership.rb
+++ b/app/models/user_group_membership.rb
@@ -6,12 +6,12 @@ require_dependency YourPlatform::Engine.root.join( 'app/models/user_group_member
 # This class represents a UserGroupMembership of the platform.
 #
 class UserGroupMembership
-  # Override the flush_cache_ugm method in order to delete specific cache
+  # Override the flush_cache_membership method in order to delete specific cache
   #
-  alias_method :orig_flush_cache_ugm, :flush_cache_ugm
-  def flush_cache_ugm
+  alias_method :orig_flush_cache_membership, :flush_cache_membership
+  def flush_cache_membership
     Rails.cache.delete([self.user, "aktivitaetszahl"])
-    orig_flush_cache_ugm
+    self.orig_flush_cache_membership
   end
 
 end

--- a/import/groups_wingolf_am_hochschulort.json
+++ b/import/groups_wingolf_am_hochschulort.json
@@ -95,7 +95,7 @@
 	"domain": "freiburg"
     },
     {
-	"name": "Frakfurter Wingolf",
+	"name": "Frankfurter Wingolf",
 	"token": "Ft",
 	"domain": "frankfurt"
     },

--- a/spec/features/aktivmeldung_spec.rb
+++ b/spec/features/aktivmeldung_spec.rb
@@ -28,6 +28,7 @@ feature "Aktivmeldung" do
     check I18n.t(:create_account)
 
     page.find("input[name='commit']").click
+    wait_for_ajax
 
     page.should have_content "Bundesbruder Kanne"
     page.should have_content I18n.t(:date_of_birth)

--- a/spec/features/user_page_spec.rb
+++ b/spec/features/user_page_spec.rb
@@ -67,7 +67,7 @@ feature 'User page', js: false do
           page.should have_selector('a.add_button', visible: true)
 
           click_on I18n.t(:add)
-          wait_for_ajax
+          wait_for_ajax; wait_for_ajax
 
           page.should have_selector('.profile_field')
           within first '.profile_field' do
@@ -115,6 +115,7 @@ feature 'User page', js: false do
         within('.box.section.access') do
 
           click_on I18n.t(:edit)
+          wait_for_ajax; wait_for_ajax
           page.should have_button(I18n.t(:delete_account) )
 
           expect { click_on I18n.t(:delete_account) }.to change(UserAccount, :count).by -1

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,32 +116,32 @@ describe User do
       subject.should_not == "H08 E06"
     end
   end
-  
+
   describe "#wingolfit?", :focus do
-    before { @user = create(:user) }
-    subject { @user.wingolfit? }
+    before { @user2 = create( :user ) }
+    subject { @user2.wingolfit? }
     describe "for freshly created user" do
       it { should == false }
     end
     describe "for a user that has just an account" do
-      before { @user = create(:user_with_account) }
+      before { @user2 = create(:user_with_account) }
       it { should == false }
     end
     describe "for a member of a Corporation status group (except guests)" do
       before do
         @corporation = create(:corporation_with_status_groups)
-        @membership = @corporation.status_groups.first.assign_user @user
+        @membership = @corporation.status_groups.first << @user2
       end
-      it { should == true}
+      it { should == true }
       describe "when the member has died" do
-        before { @user.set_date_of_death_if_unset "01.01.2006" }
+        before { @user2.set_date_of_death_if_unset "01.01.2006" }
         it { should == true }
       end
       describe "when the user terminated his membership" do
         before do
           @former_members = @corporation.child_groups.create
           @former_members.add_flag :former_members_parent
-          @membership.promote_to @former_members, at: 2.minutes.ago
+          @user2.memberships.last.promote_to @former_members, at: 2.minutes.ago
         end
         it { should == false }
       end
@@ -149,11 +149,11 @@ describe User do
     describe "for a guest of a corporation" do
       before do
         @corporation = create(:corporation_with_status_groups)
-        @corporation.find_or_create_guests_parent_group.assign_user @user
+        @corporation.find_or_create_guests_parent_group << @user2
       end
       it { should == false }
       describe "when the guest has died" do
-        before { @user.set_date_of_death_if_unset "01.01.2006" }
+        before { @user2.set_date_of_death_if_unset "01.01.2006" }
         it { should == false }
       end
     end

--- a/spec/support/capybara/session_steps.rb
+++ b/spec/support/capybara/session_steps.rb
@@ -12,7 +12,6 @@ module SessionSteps
     user = create(:admin) if parameter == :admin
     user = create(:user_with_account) if parameter == :user
     user ||= create(:user_with_account)
-
     password = user.account.password
     login_string = user.alias
 

--- a/vendor/engines/your_platform/app/models/group.rb
+++ b/vendor/engines/your_platform/app/models/group.rb
@@ -123,7 +123,7 @@ class Group < ActiveRecord::Base
   
   def <<(object)
     if object.kind_of? User
-      self.child_users << object unless self.child_users.include? object
+      UserGroupMembership.create( {:user=>object, :group=>self} ) unless self.direct_members.include? object
     end
     if object.kind_of? Group
       self.child_groups << object unless self.child_groups.include? object

--- a/vendor/engines/your_platform/app/models/structureable.rb
+++ b/vendor/engines/your_platform/app/models/structureable.rb
@@ -8,7 +8,7 @@
 #     @page1.parent_pages << @page2
 #     @page1.parents # => [ @page2, ... ]
 #     
-#     @group.child_users << @user
+#     @group.direct_members << @user
 #     @group.children # => [ @user, ... ]
 #     @user.parents # => [ @group, ... ]
 # 

--- a/vendor/engines/your_platform/app/models/user_group_membership_mixins/validity_range.rb
+++ b/vendor/engines/your_platform/app/models/user_group_membership_mixins/validity_range.rb
@@ -66,6 +66,20 @@ module UserGroupMembershipMixins::ValidityRange
   def make_invalid(time = Time.zone.now)
     time = time[:at] if time.kind_of?(Hash) && time[:at]
     self.update_attribute(:valid_to, time)
+    self.save
+    return self
+  end
+
+  # This method rebegins the membership, i.e. sets the end of the validity range
+  # to undefined.
+  #
+  # The following examples are equivalent (despite the return value):
+  #
+  #     membership.make_valid                                    #  => membership
+  #
+  def make_valid()
+    self.update_attribute(:valid_to, nil)
+    self.save    
     return self
   end
   

--- a/vendor/engines/your_platform/app/models/user_group_membership_mixins/validity_range_for_indirect_memberships.rb
+++ b/vendor/engines/your_platform/app/models/user_group_membership_mixins/validity_range_for_indirect_memberships.rb
@@ -128,7 +128,7 @@ module UserGroupMembershipMixins::ValidityRangeForIndirectMemberships
       end
     end
   end
-  private :recalculate_indirect_validity_ranges_if_needed
+
   
   
 

--- a/vendor/engines/your_platform/app/models/workflow_kit/add_to_group_brick.rb
+++ b/vendor/engines/your_platform/app/models/workflow_kit/add_to_group_brick.rb
@@ -15,7 +15,10 @@ module WorkflowKit
       user = User.find( params[ :user_id ] )  
       group = Group.find( params[ :group_id ] )
 
-      UserGroupMembership.create( user: user, group: group )
+      membership = UserGroupMembership.find_by( user: user, group: group )
+      membership ||= UserGroupMembership.create( user: user, group: group )
+
+      membership.try( :make_valid )
     end
   end
 end

--- a/vendor/engines/your_platform/app/models/workflow_kit/remove_from_group_brick.rb
+++ b/vendor/engines/your_platform/app/models/workflow_kit/remove_from_group_brick.rb
@@ -17,9 +17,9 @@ module WorkflowKit
       membership = UserGroupMembership.find_by( user: user, group: group )
       if membership
         if membership.direct?
-          membership.invalidate
+          membership.invalidate(Time.zone.now-1.second)
         else
-          membership.direct_memberships.each { |m| m.invalidate } 
+          membership.direct_memberships.each { |m| m.invalidate(Time.zone.now-1.second) }
         end
       end
     end

--- a/vendor/engines/your_platform/app/views/groups/show.html.haml
+++ b/vendor/engines/your_platform/app/views/groups/show.html.haml
@@ -29,9 +29,9 @@
 
     %span#group_members
 
-      / child users
+      / members
       = will_paginate @members if @members
-      %ul.child_users
+      %ul.members
         - if @members.count > 0
           - for user in @members do
             = render partial: 'user_group_memberships/list_item', locals: {user: user, group: @group} if can? :read, user

--- a/vendor/engines/your_platform/app/views/user_group_memberships/create.js.erb
+++ b/vendor/engines/your_platform/app/views/user_group_memberships/create.js.erb
@@ -9,4 +9,4 @@ text_field.focus();
 $('.members_count').text("(<%=j @user_group_membership.group.descendant_users.count.to_s %>)");
 
 new_list_item = $("<%=j render partial: 'user_group_memberships/list_item', locals: {user_group_membership: @user_group_membership} %>");
-new_list_item.prependTo('ul.child_users').hide().show('scale', {}, 900);
+new_list_item.prependTo('ul.members').hide().show('scale', {}, 900);

--- a/vendor/engines/your_platform/spec/factories/group.rb
+++ b/vendor/engines/your_platform/spec/factories/group.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
       after :create do |group|
         10.times do
           user = create(:user, :with_address)
-          group.child_users << user
+          group.direct_members << user
         end
       end
     end
@@ -21,14 +21,14 @@ FactoryGirl.define do
     trait :with_hidden_member do
       after :create do |group|
         user = create(:user, :with_address, :hidden, last_name: 'Hidden')
-        group.child_users << user
+        group.direct_members << user
       end
     end
 
     trait :with_dead_member do
       after :create do |group|
         user = create(:user, :with_address, :dead, last_name: 'Dead')
-        group.child_users << user
+        group.direct_members << user
       end
     end
   end

--- a/vendor/engines/your_platform/spec/factories/user.rb
+++ b/vendor/engines/your_platform/spec/factories/user.rb
@@ -62,6 +62,9 @@ FactoryGirl.define do
     #
     factory :user_with_account do
       create_account true
+      after :create do |user|
+        user.save
+      end
     end
 
     # global administrator
@@ -72,6 +75,7 @@ FactoryGirl.define do
       create_account true
       
       after :create do |admin|
+        admin.save
         Group.find_everyone_group.admins << admin
       end
     end

--- a/vendor/engines/your_platform/spec/features/groups_page_spec.rb
+++ b/vendor/engines/your_platform/spec/features/groups_page_spec.rb
@@ -25,7 +25,7 @@ feature "Groups Page" do
       within('.box.section.members') do
         click_on I18n.t(:add)
 
-        page.should have_selector '#group_members ul.child_users li', count: 1
+        page.should have_selector '#group_members ul.members li', count: 1
         page.should have_text @user.title
         find('.user-select-input').value.should == ""
       end
@@ -65,7 +65,7 @@ feature "Groups Page" do
 
     scenario 'should not render list entries for hidden or dead members' do
       visit group_path(@group)
-      page.should have_selector '#group_members ul.child_users li', count: 10
+      page.should have_selector '#group_members ul.members li', count: 10
       page.should have_no_text 'Hidden'
       page.should have_no_text 'Dead'
     end

--- a/vendor/engines/your_platform/spec/models/group_mixins/corporations_spec.rb
+++ b/vendor/engines/your_platform/spec/models/group_mixins/corporations_spec.rb
@@ -18,7 +18,7 @@ describe GroupMixins::Corporations do
       @corporation_group_of_user.parent_groups << @corporations_parent_group
       @subgroup = create( :group ); @subgroup.parent_groups << @corporation_group_of_user
       @user = create( :user ); @user.parent_groups << @subgroup
-      @non_corporations_branch_group = create( :group ); @non_corporations_branch_group.child_users << @user
+      @non_corporations_branch_group = create( :group ); @non_corporations_branch_group.direct_members << @user
     end
 
     describe ".create_corporations_parent_group" do

--- a/vendor/engines/your_platform/spec/models/group_spec.rb
+++ b/vendor/engines/your_platform/spec/models/group_spec.rb
@@ -137,17 +137,6 @@ describe Group do
       end
     end
 
-    describe "#child_users" do
-      describe "for usual groups" do
-        before { @user.parent_groups << @group }
-        subject { @group.child_users }
-
-        it "should return all child users" do
-          subject.should include( @user )
-        end
-      end
-    end
-
   end
 
 
@@ -237,12 +226,18 @@ describe Group do
     describe "(user)" do
       before do
         @user = create(:user)
+        @user.save!
         @object_to_add = @user
       end
-      it "should add the user as a child user" do
-        @group.child_users.should_not include @user
+      it "should add the user as a group's user" do
+        @group.members.should be_empty
+        @user.groups.should be_empty
         subject
-        @group.child_users.should include @user
+        @user.groups.should include @group
+        @user.parent_groups.should include @group
+        @group.members.should include @user
+        @group.memberships.first.should eq( @user.memberships.first )
+        @group.direct_memberships.first.should eq( @user.direct_memberships.first )
       end
     end
     

--- a/vendor/engines/your_platform/spec/models/post_spec.rb
+++ b/vendor/engines/your_platform/spec/models/post_spec.rb
@@ -187,8 +187,8 @@ describe Post do
   #         @message = self.send(message_type)
   #         # the email used is sent to test-group@exmaple.com
   #         @group = create(:group, name: "Test Group")
-  #         @group.child_users << create(:user) << create(:user)
-  #         @users = @group.child_users
+  #         @group.direct_members << create(:user) << create(:user)
+  #         @users = @group.direct_members
   #         @post = Post.create_from_message(@message)
   #       end
   # 

--- a/vendor/engines/your_platform/spec/models/status_group_membership_spec.rb
+++ b/vendor/engines/your_platform/spec/models/status_group_membership_spec.rb
@@ -341,6 +341,7 @@ describe StatusGroupMembership do
       it "should not remove the first status group from the user's status groups" do
         status_groups_of_user_and_corporation.should include first_status_group_membership
         subject
+        sleep 2
         status_groups_of_user_and_corporation.should include first_status_group_membership
       end
     end

--- a/vendor/engines/your_platform/spec/models/structureable_mixins/has_special_groups_spec.rb
+++ b/vendor/engines/your_platform/spec/models/structureable_mixins/has_special_groups_spec.rb
@@ -400,9 +400,9 @@ describe StructureableMixins::HasSpecialGroups do
       context "for an existing special group" do
         before { @my_structureable.create_testers_parent_group }
         it "should add the user" do
-          @my_structureable.find_testers_parent_group.child_users.should == []
+          @my_structureable.find_testers_parent_group.members.should == []
           subject
-          @my_structureable.find_testers_parent_group.child_users.should == [ @tester_user ]
+          @my_structureable.find_testers_parent_group.members.should == [ @tester_user ]
         end
       end
       context "for a non-existing special group" do
@@ -414,7 +414,7 @@ describe StructureableMixins::HasSpecialGroups do
         it "should add the user" do
           @my_structureable.find_testers_parent_group.should == nil
           subject
-          @my_structureable.find_testers_parent_group.child_users.should == [ @tester_user ]
+          @my_structureable.find_testers_parent_group.members.should == [ @tester_user ]
         end
       end
     end

--- a/vendor/engines/your_platform/spec/models/structureable_mixins/roles_spec.rb
+++ b/vendor/engines/your_platform/spec/models/structureable_mixins/roles_spec.rb
@@ -79,7 +79,7 @@ describe StructureableMixins::Roles do
     context "if admin users exist" do
       before do 
         @admin_user = create( :user )
-        @my_structureable.admins_parent.child_users << @admin_user
+        @my_structureable.admins_parent << @admin_user
       end
       it "should return an array of admin users" do
         subject.should == [ @admin_user ]
@@ -101,7 +101,7 @@ describe StructureableMixins::Roles do
     context "if admin users exist" do
       before do 
         @admin_user = create( :user )
-        @my_structureable.admins_parent.child_users << @admin_user
+        @my_structureable.admins_parent << @admin_user
       end
       it "should return an array of admin users" do
         subject.should == [ @admin_user ]
@@ -126,7 +126,7 @@ describe StructureableMixins::Roles do
       end
       it "should add the user to the group, not only the array" do
         subject
-        @my_structureable.admins_parent.child_users.should include @admin_user
+        @my_structureable.admins_parent.direct_members.should include @admin_user
       end
     end
     context "for the admin group not existing" do
@@ -425,7 +425,7 @@ describe StructureableMixins::Roles do
     end
     specify "users of this group should also be members of the admins_parent_group" do
       @user = create( :user )
-      @my_structureable.main_admins_parent.child_users << @user 
+      @my_structureable.main_admins_parent << @user 
       @user.ancestor_groups.should include( @my_structureable.admins_parent, 
                                             @my_structureable.main_admins_parent )
     end
@@ -442,7 +442,7 @@ describe StructureableMixins::Roles do
       end
       it "should list main_admins added directly to the dag" do
         @my_structureable.main_admins_parent.should be_kind_of Group
-        @my_structureable.main_admins_parent.child_users << @admin_user
+        @my_structureable.main_admins_parent << @admin_user
         subject.should include @admin_user
       end
       it "should list main_admins added by 'main_admins << user'" do
@@ -569,8 +569,8 @@ describe StructureableMixins::Roles do
       @subgroup_officers_parent = @container_subgroup.create_officers_parent_group
       @officer1 = create( :group ); @officer1.parent_groups << @officers_parent
       @officer2 = create( :group ); @officer2.parent_groups << @subgroup_officers_parent
-      @officer1_user = create( :user ); @officer1.child_users << @officer1_user
-      @officer2_user = create( :user ); @officer2.child_users << @officer2_user
+      @officer1_user = create( :user ); @officer1.direct_members << @officer1_user
+      @officer2_user = create( :user ); @officer2.direct_members << @officer2_user
       @container_group.reload
       @container_subgroup.reload
       @officers_parent.reload

--- a/vendor/engines/your_platform/spec/models/user_spec.rb
+++ b/vendor/engines/your_platform/spec/models/user_spec.rb
@@ -422,40 +422,40 @@ describe User do
   end
 
   describe "#create_account attribute" do
-    describe "#create_account == true" do
-      it "should cause the user to be created with account" do
-        create( :user, create_account: true ).account.should_not be_nil
-      end
+    it "#create_account == true" do
+      @user2 = create( :user, :create_account => true ) 
+      @user2.save
+      expect(@user2.account).to be
     end
-    describe "#create_account == false" do
-      it "should cause the user to be created without account" do
-        create( :user, create_account: false ).account.should be_nil
-      end
+    it "#create_account == 1" do
+      @user2 = create( :user, :create_account => 1 ) 
+      @user2.save
+      expect(@user2.account).to be
     end
-    describe "#create_account == 0" do
-      it "should cause the user to be created without account" do
-        create( :user, create_account: 0 ).account.should be_nil
-      end
+    it "#create_account == '1'" do
+      @user2 = create( :user, :create_account => "1" ) 
+      @user2.save
+      expect(@user2.account).to be
     end
-    describe "#create_account == 1" do
-      it "should cause the user to be created with account" do
-        create( :user, create_account: 1 ).account.should_not be_nil
-      end
+    it "#create_account == false" do
+      @user2 = create( :user, :create_account => false ) 
+      @user2.save
+      expect(@user2.account).to be_nil
     end
-    describe "#create_account == '0'" do # for HTML forms
-      it "should cause the user to be created without account" do
-        create( :user, create_account: "0" ).account.should be_nil
-      end
+    it "#create_account == 0" do
+      @user2 = create( :user, :create_account => 0 ) 
+      @user2.save
+      expect(@user2.account).to be_nil
     end
-    describe "#create_account == '1'" do # for HTML forms
-      it "should cause the user to be created with account" do
-        create( :user, create_account: "1" ).account.should_not be_nil
-      end
+    it "#create_account == '0'" do
+      @user2 = create( :user, :create_account => '0' ) 
+      @user2.save
+      expect(@user2.account).to be_nil
     end
-    describe "#create_account == ''" do
-      it "should cause the user to be created without account" do
-        create( :user, create_account: "" ).account.should be_nil
-      end
+    it "#create_account == ''" do
+      @user2 = create( :user, :create_account => '' ) 
+      @user2.save
+      expect(@user2.account).to be_nil
     end
   end
 
@@ -489,19 +489,31 @@ describe User do
       @group = create( :group )
     end
     describe "#add_to_group == nil" do
-      subject { create( :user, :add_to_group => nil ) }
+      subject do
+        @user2 = create( :user, :add_to_group => nil ) 
+        @user2.save
+        @user2
+      end
       it "should not add the user to a group during creation" do
         subject.parent_groups.should_not include( @group )
       end
     end
     describe "#add_to_group == some_group" do
-      subject { create( :user, :add_to_group => @group ) }
+      subject do
+        @user2 = create( :user, :add_to_group => @group ) 
+        @user2.save
+        @user2
+      end
       it "should add the user to the group during creation" do
         subject.parent_groups.should include( @group )
       end
     end
     describe "#add_to_group == some_group_id" do
-      subject { create( :user, :add_to_group => @group.id ) }
+      subject do
+        @user2 = create( :user, :add_to_group => @group.id ) 
+        @user2.save
+        @user2
+      end
       it "should add the user to the group during creation" do
         subject.parent_groups.should include( @group )
       end
@@ -652,7 +664,7 @@ describe User do
   describe "#memberships" do
     before do
       @group = create( :group )
-      @group.child_users << @user
+      @group << @user
       @membership = UserGroupMembership.find_by( user: @user, group: @group )
     end
     subject { @user.memberships }
@@ -735,7 +747,7 @@ describe User do
         @group_a = create( :group )
         @event_0 = @group_a.child_events.create( start_at: 5.hours.from_now )
         @group_b = @group_a.child_groups.create
-        @group_b.child_users << @user
+        @group_b << @user
         @event_1 = @group_b.child_events.create( start_at: 5.hours.from_now )
         @group_c = @group_a.child_groups.create
         @event_2 = @group_c.child_events.create( start_at: 5.hours.from_now )
@@ -790,7 +802,7 @@ describe User do
     context "for the user being a member of the object" do
       before do
         @group = create( :group )
-        @group.child_users << @user
+        @group << @user
         @object.child_groups << @group 
       end
       it { should == :member }
@@ -822,7 +834,7 @@ describe User do
 
   describe "#member_of?" do
     before do
-      @group = create( :group ); @group.child_users << @user 
+      @group = create( :group ); @group << @user 
       @page = create( :page )
     end
     context "for the user being a descendant of the object" do
@@ -875,7 +887,7 @@ describe User do
     before do 
       @group = create( :group, name: "Directly Administrated Group" )
       @group.find_or_create_admins_parent_group
-      @group.admins_parent.child_users << @user
+      @group.admins_parent << @user
     end
     subject { @user.admin_of }
     it { should == @user.administrated_objects }
@@ -890,7 +902,7 @@ describe User do
     context "for the user being admin" do
       before do
         @group.find_or_create_admins_parent_group
-        @group.admins_parent.child_users << @user  # the @user is direct admin of @group
+        @group.admins_parent << @user  # the @user is direct admin of @group
       end
       context "for directly administrated objects" do
         subject { @user.admin_of? @group }
@@ -908,7 +920,7 @@ describe User do
     context "for the user being main admin" do
       before do
         @group.create_main_admins_parent_group
-        @group.main_admins_parent.child_users << @user
+        @group.main_admins_parent << @user
       end
       subject { @user.admin_of? @group }
       it { should == true }
@@ -928,7 +940,7 @@ describe User do
     subject { @user.directly_administrated_objects }
     it { should be_kind_of Array }
     context "for the user being admin of objects" do
-      before { @group.admins_parent.child_users << @user }
+      before { @group.admins_parent << @user }
       it "should list the objects the user is directly admin of" do
         subject.should include @group
       end
@@ -943,10 +955,10 @@ describe User do
     subject { @user.administrated_objects }
     it { should be_kind_of Array }
     context "for the user being admin of an object" do
-      before { @group.admins_parent.child_users << @user }
+      before { @group.admins_parent << @user }
       it "should list all objects administrated by the user" do
         @group.admins_parent.should be_kind_of Group
-        @group.admins_parent.child_users.should include @user
+        @group.admins_parent.direct_members.should include @user
         subject.should include @group
       end
     end
@@ -954,7 +966,7 @@ describe User do
       before do
         @sub_group = create( :group, name: "Indirectly Administrated Group" )
         @sub_group.parent_groups << @group
-        @group.admins_parent.child_users << @user
+        @group.admins_parent << @user
       end
       it "should list directly and indirectly administrated objects" do
         subject.should include( @group, @sub_group )
@@ -1011,7 +1023,7 @@ describe User do
       context "for the user being just a regular member of the object" do
         before do
           @group = create( :group )
-          @group.child_users << @user
+          @group << @user
           @page.child_groups << @group
         end
         it "should be false" do

--- a/vendor/engines/your_platform/spec/models/workflow_kit/add_to_group_brick_spec.rb
+++ b/vendor/engines/your_platform/spec/models/workflow_kit/add_to_group_brick_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe "AddToGroupBrick: " do
+
+  describe "AddToGroupBrick" do
+    before do
+      @user = create( :user )
+      @indirect_group = create(:group)
+      @indirect_group.name = "indirect"
+      @indirect_group.save
+      @direct_group_a = @indirect_group.child_groups.create
+      @direct_group_a.name = "A"
+      @direct_group_a << @user
+      @direct_group_a.save
+      @direct_group_b = @indirect_group.child_groups.create
+      @direct_group_b.name = "B"
+      @direct_group_b.save
+      @workflow = Workflow.create( name: "promotion", description: "Promote a user from one group to another" )
+      @workflow.steps.create( brick_name: "RemoveFromGroupBrick", parameters: { :group_id => @indirect_group.id }, :sequence_index => 1 )
+      @workflow.steps.create( brick_name: "AddToGroupBrick", parameters: { :group_id => @direct_group_b.id }, :sequence_index => 2 )
+      @workflow.steps.create( brick_name: "RemoveFromGroupBrick", parameters: { :group_id => @indirect_group.id }, :sequence_index => 3 )
+      @workflow.steps.create( brick_name: "AddToGroupBrick", parameters: { :group_id => @direct_group_a.id }, :sequence_index => 4 )
+    end
+
+    describe "#execute" do
+      subject { @user.direct_memberships.collect{ |x| x.group } }
+      describe "initially" do
+        it do
+          should include @direct_group_a
+          should have(1).item
+        end
+      end
+      describe "after workflow step 1 execution" do
+        before do
+          @workflow.steps.first.execute( :user_id => @user.id )
+        end
+        it do
+          should_not include @direct_group_a
+          should have(0).items
+        end
+      end
+      describe "after workflow step 2 execution" do
+        before do
+          @workflow.steps[0].execute( :user_id => @user.id )
+          @workflow.steps[1].execute( :user_id => @user.id )
+        end
+        it do
+          should include @direct_group_b
+          should have(1).item
+        end
+      end
+      describe "after workflow step 3 execution" do
+        before do
+          @workflow.steps[0].execute( :user_id => @user.id )
+          @workflow.steps[1].execute( :user_id => @user.id )
+          @workflow.steps[2].execute( :user_id => @user.id )
+        end
+        it do
+          should_not include @direct_group_b
+          should have(0).items
+        end
+      end
+      describe "after workflow execution" do
+        before { @workflow.execute( :user_id => @user.id ) }
+        it do
+          should include @direct_group_a
+          should have(1).item
+        end
+      end
+    end
+  end
+end
+

--- a/vendor/engines/your_platform/spec/models/workflow_kit/remove_from_group_brick_spec.rb
+++ b/vendor/engines/your_platform/spec/models/workflow_kit/remove_from_group_brick_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe "RemoveFromGroupBrick: " do
+
+  describe "RemoveFromGroupBrick" do
+    before do
+      @user = create( :user )
+      @indirect_group = create(:group)
+      @indirect_group.name = "indirect"
+      @indirect_group.save
+      @direct_group_a = @indirect_group.child_groups.create
+      @direct_group_a.name = "A"
+      @direct_group_a << @user
+      @direct_group_a.save
+      @direct_group_b = @indirect_group.child_groups.create
+      @direct_group_b.name = "B"
+      @direct_group_b.save
+      @workflow = Workflow.create( name: "promotion", description: "Promote a user from one group to another" )
+      @workflow.steps.create( brick_name: "RemoveFromGroupBrick", parameters: { :group_id => @indirect_group.id }, :sequence_index => 1 )
+      @workflow.steps.create( brick_name: "AddToGroupBrick", parameters: { :group_id => @direct_group_b.id }, :sequence_index => 2 )
+    end
+
+    describe "#execute" do
+      subject { @user.direct_memberships.collect{ |x| x.group } }
+      describe "initially" do
+        it do
+          should include @direct_group_a
+          should have(1).item
+        end
+      end
+      describe "after workflow step 1 execution" do
+        before do
+          @workflow.steps.first.execute( :user_id => @user.id )
+        end
+        it do
+          should_not include @direct_group_a
+          should have(0).items
+        end
+      end
+      describe "after workflow execution" do
+        before { @workflow.execute( :user_id => @user.id ) }
+        it do
+          should include @direct_group_b
+          should have(1).item
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Wenn ein Benutzer von einer Gruppe in eine andere wechselt, wird er aus der anderen Gruppe nicht entfernt, sondern lediglich die Gültigkeit wird invalidiert. Wenn er dann später wieder Mitglied in dieser Gruppe ist, dann ist er zweimal Mitglied in derselben Gruppe. Jede Mitgliedschaft hat aber unterschiedliche Gültigkeit.

Dazu habe ich 
1. Specs geschrieben, die den Promotion-Workflow und die Bricks testen
2. Die Callbacks am User zum Anlegen eines Accounts und zum Zuordnen zu einer Gruppe habe ich entfernt und stattdessen die save-Methode überschrieben.
3. Das Akronym ugm durch membership ersetzt
4. Bei diversen Specs Wartezeiten eingebaut 
5. Invalidieren einer UserGroupMembership erfolgt eine Sekunde vorher, damit sie jetzt bereits ungütlig ist
6. child_users<< ersetzt
7. Das Email-Format berichtigt
