### PR TITLE
Repair SimpleCov and add your_platform to scanned classes.

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,14 @@
+# This is the shared SimpleCov configuration. It will be called whenever the simplecov gem is required.
+SimpleCov.start :rails do
+  # For reasons yet unknown, the default formatter seems to be overwritten by our app
+  # so reset it
+  formatter = SimpleCov::Formatter::HTMLFormatter
+
+  # SimpleCov filters out every non-App code, including your_platform
+  # for now, we want to include it.
+  # TODO: Remove this code when the your_platform gem has been extracted
+  filters.clear # This will remove the :root_filter that comes via simplecov's defaults
+  add_filter do |src|
+    !(src.filename =~ /^#{SimpleCov.root}/) unless src.filename =~ /your_platform/
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,6 @@ Spork.prefork do
   #
   unless ENV['DRB']
     require 'simplecov'
-    SimpleCov.start 'rails'
   end
 
 
@@ -317,7 +316,6 @@ Spork.each_run do
   #
   if ENV['DRB']
     require 'simplecov'
-    SimpleCov.start 'rails'
   end
   
 end


### PR DESCRIPTION
It seems that the default formatter gets deleted by our app. Unfortunately, I don't know the reason for that. But it can be fixed by (re-)setting the default formatter.
Additionally, the filters can be tweaked so that the your_platform gets included in the SimpleCov report.
