### PR TITLE
Replace cached_my_groups_table by cached_corporations

### DIFF
--- a/app/views/layouts/wingolf.html.haml
+++ b/app/views/layouts/wingolf.html.haml
@@ -30,7 +30,7 @@
                 -# link_to t( :my_groups ), main_app.my_groups_path, class: 'dropdown-toggle', data: { toggle: 'dropdown' }
                 = link_to t(:my_groups), my_groups_path, class: 'dropdown-toggle'
                 %ul.dropdown-menu
-                  = cached_my_groups_table
+                  = groups_of_user_table current_user
               - # /
               - #   \//
               - #   <haml:silent>             if current_user.role_for( @navable )

--- a/lib/tasks/patch_groups.rake
+++ b/lib/tasks/patch_groups.rake
@@ -99,7 +99,6 @@ namespace :patch do
           membership = UserGroupMembership.with_invalid.find_by_user_and_group(user, group)
           if membership
             membership.recalculate_validity_range_from_direct_memberships!
-            Rails.cache.delete [user, "my_groups_table"]
             print ".".green
             counter += 1 
           else

--- a/vendor/engines/your_platform/app/helpers/groups_helper.rb
+++ b/vendor/engines/your_platform/app/helpers/groups_helper.rb
@@ -1,15 +1,5 @@
 module GroupsHelper
   
-  def my_groups_table
-    groups_of_user_table current_user if current_user
-  end
-
-  def cached_my_groups_table
-    if current_user
-      Rails.cache.fetch([current_user, "my_groups_table"]) { my_groups_table }
-    end
-  end
-  
   def groups_of_user_table( user )
     content_tag :table, :class => "user_groups" do
       content_tag :tr do
@@ -18,7 +8,7 @@ module GroupsHelper
         c = content_tag :td do
           content_tag :ul do
             
-            corporation_groups = Group.find_corporation_groups_of( user )
+            corporation_groups = user.cached_current_corporations
             if corporation_groups
               corporation_groups.collect do |group|
                 sub_group_membership_lis( user: user, group: group, indent: 0, max_indent: 3 )

--- a/vendor/engines/your_platform/app/models/user_group_membership.rb
+++ b/vendor/engines/your_platform/app/models/user_group_membership.rb
@@ -41,7 +41,6 @@ class UserGroupMembership < DagLink
   end
 
   def delete_cache_usergroupmembership
-    Rails.cache.delete([self.user, "my_groups_table"])
     Rails.cache.delete([self.user, "corporate_vita_for_user"])
     Rails.cache.delete([self.user, "last_group_in_first_corporation"])
   end

--- a/vendor/engines/your_platform/app/views/groups/index_mine.html.haml
+++ b/vendor/engines/your_platform/app/views/groups/index_mine.html.haml
@@ -3,5 +3,5 @@
   = I18n.t :my_groups
   = "(#{@groups.count})" if @groups
 %div
-  = cached_my_groups_table
+  = groups_of_user_table current_user
   

--- a/vendor/engines/your_platform/app/views/layouts/bootstrap.html.haml
+++ b/vendor/engines/your_platform/app/views/layouts/bootstrap.html.haml
@@ -51,7 +51,7 @@
                   main_app.my_groups_path,                                                     |
                   class: 'dropdown-toggle', data: { toggle: 'dropdown' } )                     |
                 %ul.dropdown-menu
-                  = cached_my_groups_table
+                  = groups_of_user_table current_user
               - if can? :manage, @navable
                 %li.backendBarItem
                   = link_to t(:you_are_admin), '#'


### PR DESCRIPTION
Ich habe den Cache für die Gruppen `my_groups_table` abgeschafft. das war ein Cache, der HTML-Code enthielt. Stattdessen wird nun im HTML-Code die Cachemethode `User#cached_current_corporations` verwendet.
Die gibt es nämlich schon und liefert schon einen Teil der anzuzeigenden Gruppen.
