### PR TITLE
Cache number of children for profile field

### DIFF
--- a/app/views/profile_fields/_profile_field.html.haml
+++ b/app/views/profile_fields/_profile_field.html.haml
@@ -32,7 +32,7 @@
 
   - # value
   %span.value-wrapper
-    - if profile_field.children.count == 0
+    - if profile_field.cached_children_count == 0
       - if can? :update, profile_field
         - if profile_field.value.blank?
           = best_in_place profile_field, :value,
@@ -46,7 +46,7 @@
         - elsif display_method[:display_with] == :markdown
           = markdown(profile_field.value)
           
-    - if profile_field.children.count > 0
+    - if profile_field.cached_children_count > 0
       %ul
         - profile_field.children.each do |child_field|
           = render partial: 'profile_fields/profile_field', object: child_field

--- a/vendor/engines/your_platform/app/models/profile_field_mixins/has_child_profile_fields.rb
+++ b/vendor/engines/your_platform/app/models/profile_field_mixins/has_child_profile_fields.rb
@@ -72,7 +72,7 @@ module ProfileFieldMixins::HasChildProfileFields
     end
 
     def build_child_fields_if_absent
-      if self.children.count == 0
+      if self.cached_children_count == 0
         build_child_fields self.keys
       end
     end

--- a/vendor/engines/your_platform/spec/models/profile_field_spec.rb
+++ b/vendor/engines/your_platform/spec/models/profile_field_spec.rb
@@ -41,7 +41,11 @@ end
 # ==========================================================================================
 
 describe ProfileFieldTypes::Organization do
-  subject { ProfileFieldTypes::Organization.create() }
+  before do
+    @organization = ProfileFieldTypes::Organization.create()
+  end
+
+  subject { @organization }
   
   # Here it is only tested whether the methods exist. The functionality is
   # provided by the same mechanism as tested unter the BankAccount section.
@@ -52,6 +56,11 @@ describe ProfileFieldTypes::Organization do
   it { should respond_to( :from= ) }
   it { should respond_to( :role ) }
   it { should respond_to( :role= ) }
+
+  describe "#cached_children_count" do
+    subject { @organization.cached_children_count }
+    it { should == 3 }
+  end
 end
 
 
@@ -59,10 +68,20 @@ end
 # ==========================================================================================
 
 describe ProfileFieldTypes::Email do
-  describe ".create" do
-    subject { ProfileFieldTypes::Email.create( label: "Email" ) }
-    its( 'children.count' ) { should == 0 }
+  before do
+    @email = ProfileFieldTypes::Email.create( label: "Email" )
   end
+
+  describe "#children.count" do
+    subject { @email.children.count }
+    it { should == 0 }
+  end
+
+  describe "#cached_children_count" do
+    subject { @email.cached_children_count }
+    it { should == 0 }
+  end
+
 end
 
 
@@ -358,6 +377,11 @@ describe ProfileFieldTypes::BankAccount do
         end
       end
     end
+  end
+
+  describe "#cached_children_count" do
+    subject { @bank_account.cached_children_count }
+    it { should == 6 }
   end
 
 end  


### PR DESCRIPTION
Es lohnt sich, die Anzahl der Kinder eines Profilfelds zu cachen, weil es viele Profilfelder gibt und weil für die Darstellung eines Profilfelds diese Info zweimal abgefragt wird.
Der Cache wird gelöscht, wenn das Profilfeld oder eines seiner (transitiven) Kinder verändert wird. 
