### PR TITLE
cached corporations instead of cached corporate vita

### DIFF
--- a/app/mailers/user_account_mailer.rb
+++ b/app/mailers/user_account_mailer.rb
@@ -7,7 +7,7 @@ class UserAccountMailer < ActionMailer::Base
     # Bundesbrüder, die nur in Estland aktiv sind, bekommen diese E-Mail auf englisch,
     # alle anderen auf deutsch.
     #
-    if @user.corporations.collect { |corporation| corporation.token } == ["Dp"]
+    if @user.cached_corporations.collect { |corporation| corporation.token } == ["Dp"]
       locale = :en
     else
       locale = :de

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,8 +134,8 @@ class User
   # This method returns the aktivitaetszahl of the user, e.g. "E10 H12".
   #
   def aktivitätszahl
-    if self.corporations
-      self.corporations
+    if self.cached_corporations
+      self.cached_corporations
       .select do |corporation|
         not (self.guest_of?(corporation)) and
         not (self.former_member_of_corporation?(corporation)) and

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -39,11 +39,10 @@
 = optional_profile_section @user.profile.section :bank_account_information
 
 - # Corporate Vita
-- if @user.corporations.count > 0
+- if @user.cached_corporations.count > 0
   %h1.section.corporate_vita= t :corporate_vita
   %div
     = render partial: 'workflow_triggers'
-    - # = cached_corporate_vita_for_user @user
     = corporate_vita_for_user @user
 
 - # Groups Box

--- a/vendor/engines/your_platform/app/helpers/corporate_vita_helper.rb
+++ b/vendor/engines/your_platform/app/helpers/corporate_vita_helper.rb
@@ -1,11 +1,4 @@
 module CorporateVitaHelper
-
-  def cached_corporate_vita_for_user( user)
-    if user
-      Rails.cache.fetch([user, "corporate_vita_for_user"]) { corporate_vita_for_user( user ) }
-    end
-  end
-
   def corporate_vita_for_user( user )
     render partial: 'users/corporate_vita', locals: { 
       user: @user,

--- a/vendor/engines/your_platform/app/models/status_group.rb
+++ b/vendor/engines/your_platform/app/models/status_group.rb
@@ -12,7 +12,7 @@ class StatusGroup < Group
   
   def self.find_all_by_user(user, options = {})
     user_groups = options[:with_invalid] ? user.ancestor_groups : user.groups
-    user.corporations.collect do |corporation|
+    user.cached_corporations.collect do |corporation|
       StatusGroup.find_all_by_corporation(corporation)
     end.flatten & user_groups
   end

--- a/vendor/engines/your_platform/app/models/user.rb
+++ b/vendor/engines/your_platform/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ActiveRecord::Base
   def delete_cache
     delete_cached_last_group_in_first_corporation
     delete_cached_current_corporations
+    delete_cached_corporations
   end
 
   # Mixins
@@ -410,10 +411,20 @@ class User < ActiveRecord::Base
     my_corporations.collect { |group| group.becomes( Corporation ) }
   end
 
+  def cached_corporations
+    Rails.cache.fetch( [self, "corporations"] ) do
+      corporations
+    end
+  end
+
+  def delete_cached_corporations
+    Rails.cache.delete( [self, "corporations"] )
+  end
+
   # This returns the corporations the user is currently member of.
   #
   def current_corporations
-    self.corporations.select do |corporation|
+    self.cached_corporations.select do |corporation|
       Role.of(self).in(corporation).current_member?
     end || []
   end

--- a/vendor/engines/your_platform/app/models/user_group_membership.rb
+++ b/vendor/engines/your_platform/app/models/user_group_membership.rb
@@ -41,7 +41,6 @@ class UserGroupMembership < DagLink
   end
 
   def delete_cache_usergroupmembership
-    Rails.cache.delete([self.user, "corporate_vita_for_user"])
     Rails.cache.delete([self.user, "last_group_in_first_corporation"])
   end
 
@@ -190,7 +189,7 @@ class UserGroupMembership < DagLink
   #
   def corporation
     if self.group && self.user
-      ( ( self.group.ancestor_groups + [ self.group ] ) && self.user.corporations ).first
+      ( ( self.group.ancestor_groups + [ self.group ] ) && self.user.cached_corporations ).first
     end
   end
 

--- a/vendor/engines/your_platform/app/views/users/_corporate_vita.html.haml
+++ b/vendor/engines/your_platform/app/views/users/_corporate_vita.html.haml
@@ -1,6 +1,6 @@
 - if user
   %table{ id: 'corporate_vita' }
-    - for corporation in user.corporations
+    - for corporation in user.cached_corporations
       %tr
         %th{ colspan: 3}= corporation.title
         - memberships = user.corporate_vita_memberships_in corporation


### PR DESCRIPTION
Der Cache für die Corporate Vita eines Benutzers ist abgeschafft. Er hatte das gerenderte Ergebnis gecacht.
Stattdessen soll die Berechnung der Corporate Vita schneller gemacht werden, indem z.B. die Korporationen des Benutzers gecacht werden. das ist die Methode `User#corporations`. 
Für die neu erstellte und an vielen Stellen verwendet Cache-Methode `User#cached_corporations` habe ich specs erstellt, die auf Ergebnisgleichheit mit der gecachten Metrhode vergleichen und zwar auch nach Veränderung von Gruppenmitgliedschaften.
TODO in weiteren Pullrequests:
- Spec, ob der Wechsel der Statusgruppe innerhalb der Korporation Probleme macht. 
- Performanceanalyse und weitere Optimierungen für Corporate Vita
