### PR TITLE
Jb/spelling

### DIFF
--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -31,5 +31,5 @@
 %p
   Die alte 
   %a(href="http://wingolf.netenviron.com") Netenviron-Plattform
-  kann noch zum Abrufen von Infromationen verwendet werden:
+  kann noch zum Abrufen von Informationen verwendet werden:
   %a(href="http://wingolf.netenviron.com") http://wingolf.netenviron.com

--- a/vendor/engines/your_platform/config/locales/devise/de.yml
+++ b/vendor/engines/your_platform/config/locales/devise/de.yml
@@ -19,6 +19,7 @@ de:
       invalid_token: 'Der Anmelde-Token ist ungültig.'
       timeout: 'Ihre Sitzung ist abgelaufen, bitte melden Sie sich erneut an.'
       inactive: 'Ihr Account ist nicht aktiv.'
+      not_found_in_database: 'Ungültige Anmeldedaten.'
     sessions:
       signed_in: 'Sie sind nun am System angemeldet. Falls Sie an einem fremden Rechner (Internetcafé etc.) arbeiten, vergessen Sie bitte nicht, sich später wieder abzumelden (rechts oben).'
       signed_out: 'Erfolgreich abgemeldet.'


### PR DESCRIPTION
Ein Schreibfehler auf der Anmeldeseite, den jeder sieht.
Außerdem eine fehlende Übersetzung, wenn man aus Versehen einen falschen Benutzernamen eingibt.
translation missing: de.devise.failure.user_account.not_found_in_database
