### PR TITLE
fix failing bootstrapping

### DIFF
--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -21,7 +21,7 @@ namespace :bootstrap do
     'add_flags_to_basic_pages',
     'add_structure'
   ]
-    
+
   task :print_info do
     Log.new.section "Bootstrapping: Creating basic groups and pages."
   end
@@ -85,10 +85,10 @@ namespace :bootstrap do
     p "Task: Adding Wingolfsblätter Abo Group"
     Group.find_or_create_wbl_abo_group
   end
-  
+
   task :add_structure => [:environment] do
     p "Task: Add basic structure."
-    # 
+    #
     # root
     #   |--- intranet_root
     #             |----------- everyone
@@ -101,13 +101,13 @@ namespace :bootstrap do
     #             |---------------- help
     #
     Page.find_root << Page.find_intranet_root
+    Page.find_intranet_root << Group.find_corporations_parent_group
+    Page.find_intranet_root << Group.find_bvs_parent_group
+    Page.find_intranet_root << Page.find_help_page
     Page.find_intranet_root << Group.everyone
     Group.everyone << Group.find_corporations_parent_group
     Group.everyone << Group.find_bvs_parent_group
     Group.everyone << Group.hidden_users
-    Page.find_intranet_root << Group.find_corporations_parent_group
-    Page.find_intranet_root << Group.find_bvs_parent_group
-    Page.find_intranet_root << Page.find_help_page
   end
 
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,37 +1,37 @@
 require 'importers/models/log'
 
 namespace :import do
-  
+
   desc "Import all date from structure files and data files of the netenv system."
   task :all do
 
-    tasks_to_execute = [ 
+    tasks_to_execute = [
       'bootstrap:all',
       'import:corporations',
       'import:bvs',
       'import:external_corporations',
-      'import:standard_workflows',
+      'import:workflows',
       'import:group_profiles',
       'import:users',
       'cache:users'
     ]
 
-    
+
     $log = Log.new
-    
+
     $log.head "Wingolfsplattform Import System"
     $log.info "Welcome. Please grab a beer and sit back."
     $log.info "This script will import everything for you."
-    
+
     $log.section "Import files"
     $log.info "Import folder: " + File.join(Rails.root, "import/")
     $log.warning "Make sure the CSV files end with an empty line."
-    
+
     $log.section "Agenda"
     display_agenda_for tasks_to_execute
-    
+
     execute tasks_to_execute
-    
+
     $log.section "Import Complete."
     $log.info "All import tasks executed. We are done."
     $log.info "Congratulations!"
@@ -39,20 +39,20 @@ namespace :import do
     $log.info "You may now visit http://wingolfsplattform.org"
     $log.info "to see the result of your hard work!"
     $log.info ""
-    
+
   end
-    
+
   def display_agenda_for(tasks_to_execute)
     system("bundle exec rake -T > /tmp/rake_toc")
     tasks_to_execute.each do |task_to_execute|
       system("cat /tmp/rake_toc |grep #{task_to_execute}")
     end
   end
-  
+
   def execute(tasks_to_execute)
     tasks_to_execute.each do |task_to_execute|
       Rake::Task[task_to_execute].invoke
     end
   end
-  
+
 end


### PR DESCRIPTION
in bootstrap.rake, first add Group.find_corporations_parent_group,
Group.find_bvs_parent_group and Page.find_help_page to the intranet
root page, and then add the other groups to Group.everyone

In import.rake change import:standard_workflows to import:workflows,
because the file 'import_standard_workflows.rake' changed its name to
'import_workflows.rake'.

Besides that the obligatory trailing whitespace fixing.