### PR TITLE
Anrede für die Support-Form (Hilfe-Knopf) ändern

### DIFF
--- a/app/views/support_requests/_text_template.html.erb
+++ b/app/views/support_requests/_text_template.html.erb
@@ -1,4 +1,10 @@
-Lieber Bundesbruder Kornder,
+<% if current_user.philister? %>
+Lieber Conphilister Back,
+<% elsif current_user.aktiver? %>
+Lieber Philister Back,
+<% else %>
+Lieber Herr Back,
+<% end %>
 
 - ich bitte um Hilfe bei folgendem Problem ...
 - ich möchte eine Adressänderung melden ...

--- a/app/views/support_requests/_text_template.html.erb
+++ b/app/views/support_requests/_text_template.html.erb
@@ -1,6 +1,6 @@
-<% if current_user.philister? %>
+<% if current_user && current_user.philister? %>
 Lieber Conphilister Back,
-<% elsif current_user.aktiver? %>
+<% elsif current_user && current_user.aktiver? %>
 Lieber Philister Back,
 <% else %>
 Lieber Herr Back,


### PR DESCRIPTION
Siehe auch: http://support.wingolfsplattform.org/tickets/2381.