### PR TITLE
"Datenschutz" hartkodiert im Footer anzeigen

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -6,6 +6,8 @@
   #footer_embedded_pages= render partial: 'layouts/footer_embedded_pages'
   #footer_navi
     %ul
+        %li
+          = link_to t(:privacy), privacy_path
       - if current_user
         %li
           %a(href="http://status.wingolf.org") Status

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -6,8 +6,8 @@
   #footer_embedded_pages= render partial: 'layouts/footer_embedded_pages'
   #footer_navi
     %ul
-        %li
-          = link_to t(:privacy), "/datenschutz"
+      %li
+        = link_to t(:privacy), "/datenschutz"
       - if current_user
         %li
           %a(href="http://status.wingolf.org") Status

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -7,7 +7,7 @@
   #footer_navi
     %ul
         %li
-          = link_to t(:privacy), privacy_path
+          = link_to t(:privacy), "/datenschutz"
       - if current_user
         %li
           %a(href="http://status.wingolf.org") Status


### PR DESCRIPTION
Wegen DSVGO
https://trello.com/c/ZMyu6HRr/1282-datenschutz-link-in-den-footer-aufnehmen

Anmerkungen:
"Privacy" auf englisch könnte man noch "Data Protection" umbenennen, aber Privacy ist auch nicht schlecht. Diese Umbenennung müsste auf your_platform erfolgen.
Eine Spec dafür gibt es nicht.
Eigentlich müsste es auch funktionieren, dass die vorhandene Seite mit dem Namen Datenschutz im Footer angezeigt wird, aber da gibt es einen Fehler bei der Seiteneinstellung "Im Footer anzeigen", der noch nicht behoben ist.