### PR TITLE
temporarely redirecting from `group_members#new` to `aktivmeldung#new`

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -1,0 +1,6 @@
+class GroupMembersController
+  def new
+    authorize! :create, User 
+    redirect_to controller: 'aktivmeldungen', action: 'new'
+  end
+end


### PR DESCRIPTION
https://trello.com/c/MzmipIol/1448-aktivmeldungsbutton-zurückholen