### PR TITLE
Tests auf Github-Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,17 +4,9 @@ jobs:
   model-specs:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v2
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: Build Docker
         run: docker-compose build tests
-      - name: Migrate database
-        run: docker-compose run tests db:create db:migrate
       - name: Run tests
         run: docker-compose run tests
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+on: [push]
+jobs:
+  model-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: Build Docker
+        run: docker-compose build tests
+      - name: Migrate database
+        run: docker-compose run tests db:create db:migrate
+      - name: Run tests
+        run: docker-compose run tests
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Build Docker
-        run: docker-compose build tests
+      - name: Build docker images
+        run: docker-compose build
+      - name: Prepare database
+        run: docker-compose run tests /bin/bash -c "bundle exec rake db:create db:migrate"
       - name: Run tests
         run: docker-compose run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Build docker images
         run: docker-compose build
+      - name: Start docker containers
+        run: docker-compose up -d mysql_test redis neo4j
       - name: Prepare database
         run: docker-compose run tests /bin/bash -c "bundle exec rake db:create db:migrate"
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os: linux
-dist: trusty
-services:
-  - docker
-install:
-  - docker-compose build tests
-  - docker-compose run tests bundle exec rake db:create db:migrate
-script:
-  - docker-compose run tests

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 ## Wingolfsplattform
 
-[![Gitter](https://badges.gitter.im/Join_Chat.svg)](https://gitter.im/fiedl/wingolfsplattform?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Build Status on master](https://travis-ci.org/fiedl/wingolfsplattform.png?branch=master "master")](https://travis-ci.org/fiedl/wingolfsplattform)
-[![security](https://hakiri.io/github/fiedl/wingolfsplattform/master.svg)](https://hakiri.io/github/fiedl/wingolfsplattform/master)
-
 Dies ist der Quellcode der entstehenden neuen Plattform des Wingolfsbundes, der sog. **Wingolfsplattform**. Die Plattform soll vier Hauptaufgaben erfüllen: Hilfestellung bei der Verwaltung der Mitglieder des Wingolfs, Netzwerk der Mitglieder, Austausch von Informationen und Dokumenten, Präsentation nach außen.
 
 **Ansprechpartner**:
@@ -58,9 +54,6 @@ Bitte macht euch mit dem [Rails-Security-Guide](http://guides.rubyonrails.org/se
 
 * [Trello Board "AK Internet: Entwicklung"](https://trello.com/board/ak-internet-entwicklung/50006d110ad48e941e8496d2)
 * YourPlatform-Projekt, https://github.com/fiedl/your_platform
-
-
-[![Travis-CI-Server](https://raw.githubusercontent.com/fiedl/wingolfsplattform/master/public/images/supporttravis.png)](http://travis-ci.org)
 
 
 ### Urheber, Mitarbeiter und Lizenz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - mysql_test
       - redis
       - neo4j
+    links:
+      - "mysql_test:mysql"
     command: /bin/bash -c "bundle exec rake db:create db:migrate && bundle exec rspec spec/models"
 
   mysql:

--- a/spec/features/aktivmeldung_spec.rb
+++ b/spec/features/aktivmeldung_spec.rb
@@ -526,7 +526,6 @@ feature "Aktivmeldung" do
 
   scenario "leaving out a required field when entering aktivmeldung", :js do
     @corporation = create(:wingolf_corporation)
-    p "This line is to prevent travis from hanging up."
     login :admin
 
     visit group_members_path(@corporation.aktivitas)

--- a/spec/features/bv_admin_spec.rb
+++ b/spec/features/bv_admin_spec.rb
@@ -12,72 +12,70 @@ feature "BV-Admins" do
     login @bv_admin
   end
 
-  if ENV['CI'] != 'travis'  # TODO: Why does this fail on travis, but work locally?
-    scenario "Managing Officers through officers#index", :js do
-      @bv_leiter = @bv.create_officer_group name: "BV-Leiter"
-      @bv_leiter.add_flag :bv_leiter
+  scenario "Managing Officers through officers#index", :js do
+    @bv_leiter = @bv.create_officer_group name: "BV-Leiter"
+    @bv_leiter.add_flag :bv_leiter
 
-      visit group_officers_path(@bv)
-      within '.box.first' do
-        # Admins and BV-Leiter should already be listed.
-        page.should have_text I18n.t(:admins)
-        page.should have_text @bv_admin.name
-        page.should have_text "BV-Leiter"
+    visit group_officers_path(@bv)
+    within '.box.first' do
+      # Admins and BV-Leiter should already be listed.
+      page.should have_text I18n.t(:admins)
+      page.should have_text @bv_admin.name
+      page.should have_text "BV-Leiter"
 
-        # The admin can't rename the officer group which has a flag.
-        click_on I18n.t(:edit)
-        page.should have_no_selector "input[value='#{@bv_leiter.name}']"
-
-        # But he can assign users.
-        fill_in :direct_members_titles_string, with: @user.title
-        find('.save_button').click
-        page.should have_text I18n.t(:admins)
-        page.should have_text "BV-Leiter"
-        page.should have_text @user.name, count: 2
-
-        # He can create a new office.
-        within '#new_officer_group' do
-          fill_in 'officer_group_name', with: 'Bierkassenwart'
-          find('input[type="submit"]').click
-        end
-        page.should have_text "Bierkassenwart"
-
-        # He could desstroy the new office.
-        click_on I18n.t(:edit)
-        page.should have_selector '.remove_button', count: 1
-
-        # He can rename the new office, which has no flag.
-        # TODO: page.should have_selector "input[value='Bierkassenwart']"
-        within all("td.name").last do
-          fill_in :name, with: 'Getränkekassenwart'
-        end
-        find('.save_button').click
-        page.should have_text 'Getränkekassenwart'
-      end
-
-      wait_until { OfficerGroup.last.name == 'Getränkekassenwart' }
-
-      # The changes should be persistent:
-      visit group_officers_path(@bv)
-      within '.box.first' do
-        page.should have_text I18n.t(:admins)
-        page.should have_text "BV-Leiter"
-        page.should have_text @user.name, count: 2
-        page.should have_text 'Getränkekassenwart'
-      end
-
-      # He can destroy only the new office, which has no members and no flags.
+      # The admin can't rename the officer group which has a flag.
       click_on I18n.t(:edit)
-      within '.box.first' do
-        find('.remove_button').click
-        page.should have_no_text "Getränkekassenwart"
-      end
+      page.should have_no_selector "input[value='#{@bv_leiter.name}']"
 
-      # The change should be persistent:
-      visit group_officers_path(@bv)
-      within '.box.first' do
-        page.should have_no_text "Getränkekassenwart"
+      # But he can assign users.
+      fill_in :direct_members_titles_string, with: @user.title
+      find('.save_button').click
+      page.should have_text I18n.t(:admins)
+      page.should have_text "BV-Leiter"
+      page.should have_text @user.name, count: 2
+
+      # He can create a new office.
+      within '#new_officer_group' do
+        fill_in 'officer_group_name', with: 'Bierkassenwart'
+        find('input[type="submit"]').click
       end
+      page.should have_text "Bierkassenwart"
+
+      # He could desstroy the new office.
+      click_on I18n.t(:edit)
+      page.should have_selector '.remove_button', count: 1
+
+      # He can rename the new office, which has no flag.
+      # TODO: page.should have_selector "input[value='Bierkassenwart']"
+      within all("td.name").last do
+        fill_in :name, with: 'Getränkekassenwart'
+      end
+      find('.save_button').click
+      page.should have_text 'Getränkekassenwart'
+    end
+
+    wait_until { OfficerGroup.last.name == 'Getränkekassenwart' }
+
+    # The changes should be persistent:
+    visit group_officers_path(@bv)
+    within '.box.first' do
+      page.should have_text I18n.t(:admins)
+      page.should have_text "BV-Leiter"
+      page.should have_text @user.name, count: 2
+      page.should have_text 'Getränkekassenwart'
+    end
+
+    # He can destroy only the new office, which has no members and no flags.
+    click_on I18n.t(:edit)
+    within '.box.first' do
+      find('.remove_button').click
+      page.should have_no_text "Getränkekassenwart"
+    end
+
+    # The change should be persistent:
+    visit group_officers_path(@bv)
+    within '.box.first' do
+      page.should have_no_text "Getränkekassenwart"
     end
   end
 

--- a/spec/models/app_version_spec.rb
+++ b/spec/models/app_version_spec.rb
@@ -1,38 +1,37 @@
 require 'spec_helper'
 
 describe AppVersion do
-  if ENV['CI'] != 'travis' # because the git commands do not work there.
-  
-    subject { AppVersion }
-    it { should respond_to :last_tag }
-    it { should respond_to :version }
-    it { should respond_to :commit_id }
-    it { should respond_to :short_commit_id }
-    it { should respond_to :github_commit_url }
-    
-    describe ".last_tag" do
-      subject { AppVersion.last_tag }
-      it { should be_present }
-      it { should_not include "\n" }
-      it { should start_with "v" }
-    end
-    describe ".version" do
-      subject { AppVersion.version }
-      it { should be_present }
-      it { should_not include "\n" }
-      it { should_not start_with "v" }
-    end
-    describe ".github_commit_url" do
-      subject { AppVersion.github_commit_url }
-      it { should == "https://github.com/fiedl/wingolfsplattform/commit/#{AppVersion.commit_id}" }
-    end
-    describe ".changelog_url" do
-      subject { AppVersion.changelog_url }
-      it { should = "https://github.com/fiedl/wingolfsplattform/commits/#{AppVersion.branch}" }
-    end
-    describe ".app_name" do
-      subject { AppVersion.app_name }
-      it { should == "Wingolfsplattform" }
-    end
+
+  subject { AppVersion }
+  it { should respond_to :last_tag }
+  it { should respond_to :version }
+  it { should respond_to :commit_id }
+  it { should respond_to :short_commit_id }
+  it { should respond_to :github_commit_url }
+
+  describe ".last_tag" do
+    subject { AppVersion.last_tag }
+    it { should be_present }
+    it { should_not include "\n" }
+    it { should start_with "v" }
   end
+  describe ".version" do
+    subject { AppVersion.version }
+    it { should be_present }
+    it { should_not include "\n" }
+    it { should_not start_with "v" }
+  end
+  describe ".github_commit_url" do
+    subject { AppVersion.github_commit_url }
+    it { should == "https://github.com/fiedl/wingolfsplattform/commit/#{AppVersion.commit_id}" }
+  end
+  describe ".changelog_url" do
+    subject { AppVersion.changelog_url }
+    it { should = "https://github.com/fiedl/wingolfsplattform/commits/#{AppVersion.branch}" }
+  end
+  describe ".app_name" do
+    subject { AppVersion.app_name }
+    it { should == "Wingolfsplattform" }
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,11 +140,7 @@ end
 #
 # See: https://github.com/jnicklas/capybara#asynchronous-javascript-ajax-and-friends
 #
-Capybara.default_max_wait_time = if ENV['CI'] == 'travis'
-  120 # travis is much slower and might take longer to process stuff
-else
-  30
-end
+Capybara.default_max_wait_time = 30
 
 # Background Jobs:
 # Perform all background jobs immediately.


### PR DESCRIPTION
## Travis-Sunset

Unser Projekt war damals Crowd-Funder für Travis-CI. Leider wird travis-ci.org eingestellt: https://blog.travis-ci.com/2021-05-07-orgshutdown.

Ich habe versucht, das Projekt nach travis-ci.com zu übertragen. Dort jedoch wird die Teilnahme an einem Beta-Programm verlangt. Unser Beta-Schlüssel von damals ist anscheinend nicht mehr gültig. Daher können die Tests zur Zeit nicht mehr auf Travis-CI ausgeführt werden.

## Github-Actions

Ich richte die docker-gestützten Model-Specs kurzfristig auf Github-Actions ein.
https://docs.github.com/en/actions/quickstart