### PR TITLE
Vendor the acts-as-dag fork into the engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ source 'https://rubygems.org' do
   gem 'nokogiri', '>= 1.7.1'  #  USN-3235-1
 
   # Temporary Forks and Overrides
-  gem 'acts-as-dag', git: 'https://github.com/fiedl/acts-as-dag', branch: 'sf/rails-5'
   gem 'refile', git: 'https://github.com/sobrinho/refile'
   gem 'refile-mini_magick', git: 'https://github.com/refile/refile-mini_magick'
   gem 'rails-settings-cached', '0.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/fiedl/acts-as-dag
-  revision: 5e185dddff6563ee9ee92611555cd9d9a519d280
-  branch: sf/rails-5
-  specs:
-    acts-as-dag (4.0.0)
-      activemodel
-      activerecord (>= 4.0.0)
-
-GIT
   remote: https://github.com/refile/refile-mini_magick
   revision: 27b6c6c7affcc302a59068b8b3f458cb147c2fa6
   specs:
@@ -32,7 +23,6 @@ PATH
       actionpack (>= 4.2.5.2)
       actionview (>= 5.0.7.2)
       activerecord (>= 4.2.7.1)
-      acts-as-dag (>= 4.0)
       acts-as-taggable-on (~> 4.0)
       acts_as_tree
       apipie-rails (~> 0.5)
@@ -626,7 +616,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts-as-dag!
   binding_of_caller!
   brakeman (>= 2.3.1)!
   capybara (~> 3.0)!

--- a/your_platform/lib/your_platform/dag.rb
+++ b/your_platform/lib/your_platform/dag.rb
@@ -1,0 +1,20 @@
+# Vendored from the acts-as-dag fork, v4.0.0:
+# https://github.com/fiedl/acts-as-dag, branch sf/rails-5,
+# revision 5e185dd, MIT license (see dag/MIT-LICENSE).
+#
+# Vendoring lets the closure-table DSL be edited in-repo while it is
+# replaced by recursive CTE queries, step by step:
+# https://github.com/fiedl/wingolfsplattform/issues/129
+
+require 'active_model'
+require 'active_record'
+
+require_relative 'dag/dag'
+require_relative 'dag/columns'
+require_relative 'dag/poly_columns'
+require_relative 'dag/polymorphic'
+require_relative 'dag/standard'
+require_relative 'dag/edges'
+require_relative 'dag/validators'
+
+ActiveRecord::Base.extend Dag

--- a/your_platform/lib/your_platform/dag/MIT-LICENSE
+++ b/your_platform/lib/your_platform/dag/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2008 Matthew Leventi
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/your_platform/lib/your_platform/dag/columns.rb
+++ b/your_platform/lib/your_platform/dag/columns.rb
@@ -1,0 +1,26 @@
+module Dag
+
+  #Methods that show columns
+  module Columns
+      def ancestor_id_column_name
+        acts_as_dag_options[:ancestor_id_column]
+      end
+
+      def descendant_id_column_name
+        acts_as_dag_options[:descendant_id_column]
+      end
+
+      def direct_column_name
+        acts_as_dag_options[:direct_column]
+      end
+
+      def count_column_name
+        acts_as_dag_options[:count_column]
+      end
+
+      def acts_as_dag_polymorphic?
+        acts_as_dag_options[:polymorphic]
+      end
+    end
+
+end

--- a/your_platform/lib/your_platform/dag/columns.rb
+++ b/your_platform/lib/your_platform/dag/columns.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/columns.rb
+#
 module Dag
 
   #Methods that show columns

--- a/your_platform/lib/your_platform/dag/dag.rb
+++ b/your_platform/lib/your_platform/dag/dag.rb
@@ -1,0 +1,300 @@
+module Dag
+
+  #Sets up a model to act as dag links for models specified under the :for option
+  def acts_as_dag_links(options = {})
+    conf = {
+            :ancestor_id_column => 'ancestor_id',
+            :ancestor_type_column => 'ancestor_type',
+            :descendant_id_column => 'descendant_id',
+            :descendant_type_column => 'descendant_type',
+            :direct_column => 'direct',
+            :count_column => 'count',
+            :polymorphic => false,
+            :node_class_name => nil}
+    conf.update(options)
+
+    unless conf[:polymorphic]
+      if conf[:node_class_name].nil?
+        raise ActiveRecord::ActiveRecordError, 'ERROR: Non-polymorphic graphs need to specify :node_class_name with the receiving class like belong_to'
+      end
+    end
+
+    class_attribute :acts_as_dag_options, :instance_writer => false
+    self.acts_as_dag_options = conf
+
+    extend Columns
+    include Columns
+
+    #access to _changed? and _was for (edge,count) if not default
+    unless direct_column_name == 'direct'
+      module_eval <<-"end_eval", __FILE__, __LINE__
+						def direct_changed?
+							self.#{direct_column_name}_changed?
+						end
+						def direct_was
+							self.#{direct_column_name}_was
+						end
+      end_eval
+    end
+
+    unless count_column_name == 'count'
+      module_eval <<-"end_eval", __FILE__, __LINE__
+						def count_changed?
+							self.#{count_column_name}_changed?
+						end
+						def count_was
+							self.#{count_column_name}_was
+						end
+      end_eval
+    end
+
+    internal_columns = [ancestor_id_column_name, descendant_id_column_name]
+    edge_class_name = self.to_s
+
+    direct_column_name.intern
+    count_column_name.intern
+
+    #links to ancestor and descendant
+    if acts_as_dag_polymorphic?
+      extend PolyColumns
+      include PolyColumns
+
+      internal_columns << ancestor_type_column_name
+      internal_columns << descendant_type_column_name
+
+      belongs_to :ancestor, :polymorphic => true
+      belongs_to :descendant, :polymorphic => true
+
+      validates ancestor_type_column_name.to_sym, :presence => true
+      validates descendant_type_column_name.to_sym, :presence => true
+      validates ancestor_id_column_name.to_sym, :uniqueness => {:scope => [ancestor_type_column_name, descendant_type_column_name, descendant_id_column_name]}
+
+      scope :with_ancestor, lambda { |ancestor| where(ancestor_id_column_name => ancestor.id, ancestor_type_column_name => ancestor.class.to_s) }
+      scope :with_descendant, lambda { |descendant| where(descendant_id_column_name => descendant.id, descendant_type_column_name => descendant.class.to_s) }
+
+      scope :with_ancestor_point, lambda { |point| where(ancestor_id_column_name => point.id, ancestor_type_column_name => point.type) }
+      scope :with_descendant_point, lambda { |point| where(descendant_id_column_name => point.id, descendant_type_column_name => point.type) }
+
+      extend Polymorphic
+      include Polymorphic
+    else
+      belongs_to :ancestor, :foreign_key => ancestor_id_column_name, :class_name => acts_as_dag_options[:node_class_name]
+      belongs_to :descendant, :foreign_key => descendant_id_column_name, :class_name => acts_as_dag_options[:node_class_name]
+
+      validates ancestor_id_column_name.to_sym, :uniqueness => {:scope => [descendant_id_column_name]}
+
+      scope :with_ancestor, lambda { |ancestor| where(ancestor_id_column_name => ancestor.id) }
+      scope :with_descendant, lambda { |descendant| where(descendant_id_column_name => descendant.id) }
+
+      scope :with_ancestor_point, lambda { |point| where(ancestor_id_column_name => point.id) }
+      scope :with_descendant_point, lambda { |point| where(descendant_id_column_name => point.id) }
+
+      extend Standard
+      include Standard
+    end
+
+    scope :direct, lambda { where(:direct => true) }
+    scope :indirect, lambda { where(:direct => false) }
+
+    scope :ancestor_nodes, lambda { joins(:ancestor) }
+    scope :descendant_nodes, lambda { joins(:descendant) }
+
+    validates :ancestor, :presence => true
+    validates :descendant, :presence => true
+
+    extend Edges
+    include Edges
+
+    before_destroy :destroyable!, :perpetuate
+    before_save :perpetuate
+    before_validation :field_check, :fill_defaults, :on => :update
+    before_validation :fill_defaults, :on => :create
+
+    include ActiveModel::Validations
+    validates_with CreateCorrectnessValidator, :on => :create
+    validates_with UpdateCorrectnessValidator, :on => :update
+
+
+    #internal fields
+    code = 'def field_check ' + "\n"
+    internal_columns.each do |column|
+      code +=  "if " + column + "_changed? \n" + ' raise ActiveRecord::ActiveRecordError, "Column: '+column+' cannot be changed for an existing record it is immutable"' + "\n end \n"
+    end
+    code += 'end'
+    module_eval code
+
+    [count_column_name].each do |column|
+      module_eval <<-"end_eval", __FILE__, __LINE__
+						def #{column}=(x)
+							raise ActiveRecord::ActiveRecordError, "ERROR: Unauthorized assignment to #{column}: it's an internal field handled by acts_as_dag code."
+						end
+      end_eval
+    end
+  end
+
+  def has_dag_links(options = {})
+    conf = {
+            :class_name => nil,
+            :prefix => '',
+            :ancestor_class_names => [],
+            :descendant_class_names => []
+    }
+    conf.update(options)
+
+    #check that class_name is filled
+    if conf[:link_class_name].nil?
+      raise ActiveRecord::ActiveRecordError, "has_dag_links must be provided with :link_class_name option"
+    end
+
+    #add trailing '_' to prefix
+    unless conf[:prefix] == ''
+      conf[:prefix] += '_'
+    end
+
+    prefix = conf[:prefix]
+    dag_link_class_name = conf[:link_class_name]
+    dag_link_class = conf[:link_class_name].constantize
+
+    if dag_link_class.acts_as_dag_polymorphic?
+      self.class_eval <<-EOL
+              has_many :#{prefix}links_as_ancestor, :as => :ancestor, :class_name => '#{dag_link_class_name}'
+              has_many :#{prefix}links_as_descendant, :as => :descendant, :class_name => '#{dag_link_class_name}'
+
+              has_many :#{prefix}links_as_parent, lambda { where('#{dag_link_class.direct_column_name}' => true) }, :as => :ancestor, :class_name => '#{dag_link_class_name}'
+              has_many :#{prefix}links_as_child, lambda { where('#{dag_link_class.direct_column_name}' => true) }, :as => :descendant, :class_name => '#{dag_link_class_name}'
+
+      EOL
+
+      ancestor_table_names = []
+      parent_table_names = []
+      conf[:ancestor_class_names].each do |class_name|
+        table_name = class_name.tableize
+        self.class_eval <<-EOL2
+                has_many :#{prefix}links_as_descendant_for_#{table_name}, lambda { where('#{dag_link_class.ancestor_type_column_name}' => '#{class_name}') }, :as => :descendant, :class_name => '#{dag_link_class_name}'
+                has_many :#{prefix}ancestor_#{table_name}, :through => :#{prefix}links_as_descendant_for_#{table_name}, :source => :ancestor, :source_type => '#{class_name}'
+                has_many :#{prefix}links_as_child_for_#{table_name}, lambda { where('#{dag_link_class.ancestor_type_column_name}' => '#{class_name}','#{dag_link_class.direct_column_name}' => true) }, :as => :descendant, :class_name => '#{dag_link_class_name}'
+                has_many :#{prefix}parent_#{table_name}, :through => :#{prefix}links_as_child_for_#{table_name}, :source => :ancestor, :source_type => '#{class_name}'
+
+              	def #{prefix}root_for_#{table_name}?
+									self.links_as_descendant_for_#{table_name}.empty?
+            		end
+        EOL2
+        ancestor_table_names << (prefix+'ancestor_'+table_name)
+        parent_table_names << (prefix+'parent_'+table_name)
+        unless conf[:descendant_class_names].include?(class_name)
+          #this apparently is only one way is we can create some aliases making things easier
+          self.class_eval "has_many :#{prefix}#{table_name}, :through => :#{prefix}links_as_descendant_for_#{table_name}, :source => :ancestor, :source_type => '#{class_name}'"
+        end
+      end
+
+      unless conf[:ancestor_class_names].empty?
+        self.class_eval <<-EOL25
+								def #{prefix}ancestors
+									#{ancestor_table_names.join(' + ')}
+								end
+								def #{prefix}parents
+									#{parent_table_names.join(' + ')}
+								end
+        EOL25
+      else
+        self.class_eval <<-EOL26
+								def #{prefix}ancestors
+									a = []
+									#{prefix}links_as_descendant.each do |link|
+										a << link.ancestor
+									end
+									a
+								end
+								def #{prefix}parents
+									a = []
+									#{prefix}links_as_child.each do |link|
+										a << link.ancestor
+									end
+									a
+								end
+        EOL26
+      end
+
+      descendant_table_names = []
+      child_table_names = []
+      conf[:descendant_class_names].each do |class_name|
+        table_name = class_name.tableize
+        self.class_eval <<-EOL3
+                has_many :#{prefix}links_as_ancestor_for_#{table_name}, lambda { where('#{dag_link_class.descendant_type_column_name}' => '#{class_name}') }, :as => :ancestor, :class_name => '#{dag_link_class_name}'
+                has_many :#{prefix}descendant_#{table_name}, :through => :#{prefix}links_as_ancestor_for_#{table_name}, :source => :descendant, :source_type => '#{class_name}'
+
+                has_many :#{prefix}links_as_parent_for_#{table_name}, lambda { where('#{dag_link_class.descendant_type_column_name}' => '#{class_name}','#{dag_link_class.direct_column_name}' => true) }, :as => :ancestor, :class_name => '#{dag_link_class_name}'
+                has_many :#{prefix}child_#{table_name}, :through => :#{prefix}links_as_parent_for_#{table_name}, :source => :descendant, :source_type => '#{class_name}'
+
+								def #{prefix}leaf_for_#{table_name}?
+                	self.links_as_ancestor_for_#{table_name}.empty?
+              	end
+        EOL3
+        descendant_table_names << (prefix+'descendant_'+table_name)
+        child_table_names << (prefix+'child_'+table_name)
+        unless conf[:ancestor_class_names].include?(class_name)
+          self.class_eval "has_many :#{prefix}#{table_name}, :through => :#{prefix}links_as_ancestor_for_#{table_name}, :source => :descendant, :source_type => '#{class_name}'"
+        end
+      end
+
+      unless conf[:descendant_class_names].empty?
+        self.class_eval <<-EOL35
+								def #{prefix}descendants
+									#{descendant_table_names.join(' + ')}
+								end
+								def #{prefix}children
+									#{child_table_names.join(' + ')}
+								end
+        EOL35
+      else
+        self.class_eval <<-EOL36
+								def #{prefix}descendants
+									d = []
+									#{prefix}links_as_ancestor.each do |link|
+										d << link.descendant
+									end
+									d
+								end
+								def #{prefix}children
+									d = []
+									#{prefix}links_as_parent.each do |link|
+										d << link.descendant
+									end
+									d
+								end
+        EOL36
+      end
+    else
+      self.class_eval <<-EOL4
+              has_many :#{prefix}links_as_ancestor, :foreign_key => '#{dag_link_class.ancestor_id_column_name}', :class_name => '#{dag_link_class_name}'
+              has_many :#{prefix}links_as_descendant, :foreign_key => '#{dag_link_class.descendant_id_column_name}', :class_name => '#{dag_link_class_name}'
+
+              has_many :#{prefix}ancestors, :through => :#{prefix}links_as_descendant, :source => :ancestor
+              has_many :#{prefix}descendants, :through => :#{prefix}links_as_ancestor, :source => :descendant
+
+              has_many :#{prefix}links_as_parent, lambda { where('#{dag_link_class.direct_column_name}' => true) }, :foreign_key => '#{dag_link_class.ancestor_id_column_name}', :class_name => '#{dag_link_class_name}', :inverse_of => :ancestor
+              has_many :#{prefix}links_as_child, lambda { where('#{dag_link_class.direct_column_name}' => true) }, :foreign_key => '#{dag_link_class.descendant_id_column_name}', :class_name => '#{dag_link_class_name}', :inverse_of => :descendant
+
+              has_many :#{prefix}parents, :through => :#{prefix}links_as_child, :source => :ancestor
+              has_many :#{prefix}children, :through => :#{prefix}links_as_parent, :source => :descendant
+
+      EOL4
+    end
+    self.class_eval <<-EOL5
+            def #{prefix}self_and_ancestors
+              [self] + #{prefix}ancestors
+            end
+            def #{prefix}self_and_descendants
+              [self] + #{prefix}descendants
+            end
+            
+            def #{prefix}leaf?
+              self.#{prefix}links_as_ancestor.empty?
+						end
+						def #{prefix}root?
+							self.#{prefix}links_as_descendant.empty?
+						end
+    EOL5
+  end
+
+end

--- a/your_platform/lib/your_platform/dag/dag.rb
+++ b/your_platform/lib/your_platform/dag/dag.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/dag.rb
+#
 module Dag
 
   #Sets up a model to act as dag links for models specified under the :for option

--- a/your_platform/lib/your_platform/dag/edges.rb
+++ b/your_platform/lib/your_platform/dag/edges.rb
@@ -1,0 +1,308 @@
+module Dag
+  module Edges
+
+    def self.included(base)
+      base.send :include, EdgeInstanceMethods
+    end
+
+    #Class methods that extend the link model for both polymorphic and non-polymorphic graphs
+    #Returns a new edge between two points
+    def build_edge(ancestor, descendant)
+      source = self::EndPoint.from(ancestor)
+      sink = self::EndPoint.from(descendant)
+      conditions = self.conditions_for(source, sink)
+      path = self.new(conditions)
+      path.make_direct
+      path
+    end
+
+    #Finds an edge between two points, Must be direct
+    def find_edge(ancestor, descendant)
+      source = self::EndPoint.from(ancestor)
+      sink = self::EndPoint.from(descendant)
+      self.where(self.conditions_for(source, sink).merge!({direct_column_name => true})).first
+    end
+
+    #Finds a link between two points
+    def find_link(ancestor, descendant)
+      source = self::EndPoint.from(ancestor)
+      sink = self::EndPoint.from(descendant)
+      self.where(self.conditions_for(source, sink)).first
+    end
+
+    #Finds or builds an edge between two points
+    def find_or_build_edge(ancestor, descendant)
+      edge = self.find_edge(ancestor, descendant)
+      return edge unless edge.nil?
+      return build_edge(ancestor, descendant)
+    end
+
+    #Creates an edge between two points using save
+    def create_edge(ancestor, descendant)
+      link = self.find_link(ancestor, descendant)
+      if link.nil?
+        edge = self.build_edge(ancestor, descendant)
+        return edge.save
+      else
+        link.make_direct
+        return link.save
+      end
+    end
+
+    #Creates an edge between two points using save! Returns created edge
+    def create_edge!(ancestor, descendant)
+      link = self.find_link(ancestor, descendant)
+      if link.nil?
+        edge = self.build_edge(ancestor, descendant)
+        edge.save!
+        edge
+      else
+        link.make_direct
+        link.save!
+        link
+      end
+    end
+
+    #Finds the longest path between ancestor and descendant returning as an array
+    def longest_path_between(ancestor, descendant, path=[])
+      longest = []
+      ancestor.children.each do |child|
+        if child == descendant
+          temp = path.clone
+          temp << child
+          if temp.length > longest.length
+            longest = temp
+          end
+        elsif self.find_link(child, descendant)
+          temp = path.clone
+          temp << child
+          temp = self.longest_path_between(child, descendant, temp)
+          if temp.length > longest.length
+            longest = temp
+          end
+        end
+      end
+      longest
+    end
+
+    #Finds the shortest path between ancestor and descendant returning as an array
+    def shortest_path_between(ancestor, descendant, path=[])
+      shortest = []
+      ancestor.children.each do |child|
+        if child == descendant
+          temp = path.clone
+          temp << child
+          if shortest.blank? || temp.length < shortest.length
+            shortest = temp
+          end
+        elsif self.find_link(child, descendant)
+          temp = path.clone
+          temp << child
+          temp = self.shortest_path_between(child, descendant, temp)
+          if shortest.blank? || temp.length < shortest.length
+            shortest = temp
+          end
+        end
+      end
+      return shortest
+    end
+
+    #Determines if an edge exists between two points
+    def edge?(ancestor, descendant)
+      !self.find_edge(ancestor, descendant).nil?
+    end
+
+    #Alias for edge
+    def direct?(ancestor, descendant)
+      self.edge?(ancestor, descendant)
+    end
+
+    #Instance methods included into the link model for polymorphic and non-polymorphic DAGs
+    module EdgeInstanceMethods
+
+      attr_accessor :do_not_perpetuate
+
+      #Fill default direct and count values if necessary. In place of after_initialize method
+      def fill_defaults
+        self[direct_column_name] = true if self[direct_column_name].nil?
+        self[count_column_name] = 0 if self[count_column_name].nil?
+      end
+
+      #Whether the edge can be destroyed
+      def destroyable?
+        (self.count == 0) || (self.direct? && self.count == 1)
+      end
+
+      #Raises an exception if the edge is not destroyable. Otherwise makes the edge indirect before destruction to cleanup graph.
+      def destroyable!
+        raise ActiveRecord::ActiveRecordError, 'ERROR: cannot destroy this edge' unless destroyable?
+        #this triggers rewiring on destruction via perpetuate
+        if self.direct?
+          self[direct_column_name] = false
+        end
+        true
+      end
+
+      #Analyzes the changes in a model instance and rewires as necessary.
+      def perpetuate
+        #flag set by links that were modified in association
+        return true if self.do_not_perpetuate
+
+        #if edge changed this was manually altered
+        if direct_changed?
+          if self.direct?
+            self[count_column_name] += 1
+          else
+            self[count_column_name] -= 1
+          end
+          self.wiring
+        end
+      end
+
+      #Id of the ancestor
+      def ancestor_id
+        self[ancestor_id_column_name]
+      end
+
+      #Id of the descendant
+      def descendant_id
+        self[descendant_id_column_name]
+      end
+
+      #Count of the edge, ie the edge exists in X ways
+      def count
+        self[count_column_name]
+      end
+
+      #Changes the count of the edge. DO NOT CALL THIS OUTSIDE THE PLUGIN
+      def internal_count=(val)
+        self[count_column_name] = val
+      end
+
+      #Whether the link is direct, ie manually created
+      def direct?
+        self[direct_column_name]
+      end
+
+      #Whether the link is an edge?
+      def edge?
+        self[direct_column_name]
+      end
+
+      #Makes the link direct, ie an edge
+      def make_direct
+        self[direct_column_name] = true
+      end
+
+      #Makes an edge indirect, ie a link.
+      def make_indirect
+        self[direct_column_name] = false
+      end
+
+      #Source of the edge, creates if necessary
+      def source
+        @source = self.class::Source.from_edge(self) if @source.nil?
+        @source
+      end
+
+      #Sink (destination) of the edge, creates if necessary
+      def sink
+        @sink = self.class::Sink.from_edge(self) if @sink.nil?
+        @sink
+      end
+
+      #All links that end at the source
+      def links_to_source
+        self.class.with_descendant_point(self.source)
+      end
+
+      #all links that start from the sink
+      def links_from_sink
+        self.class.with_ancestor_point(self.sink)
+      end
+
+      protected
+
+      # Changes on a wire based on the count (destroy or save!) (should not be called outside this plugin)
+      def push_associated_modification!(edge)
+        raise ActiveRecord::ActiveRecordError, 'ERROR: cannot modify our self in this way' if edge == self
+        edge.do_not_perpetuate = true
+        if edge.count == 0
+          edge.destroy
+        else
+          edge.save!
+        end
+      end
+
+      #Updates the wiring of edges that dependent on the current one
+      def rewire_crossing(above_leg, below_leg)
+        if above_leg.count_changed?
+          was = above_leg.count_was
+          was = 0 if was.nil?
+          above_leg_count = above_leg.count - was
+          if below_leg.count_changed?
+            raise ActiveRecord::ActiveRecordError, 'ERROR: both legs cannot 0 normal count change'
+          else
+            below_leg_count = below_leg.count
+          end
+        else
+          above_leg_count = above_leg.count
+          if below_leg.count_changed?
+            was = below_leg.count_was
+            was = 0 if was.nil?
+            below_leg_count = below_leg.count - was
+          else
+            raise ActiveRecord::ActiveRecordError, 'ERROR: both legs cannot have count changes'
+          end
+        end
+        count = above_leg_count * below_leg_count
+        source = above_leg.source
+        sink = below_leg.sink
+        bridging_leg = self.class.find_link(source, sink)
+        if bridging_leg.nil?
+          bridging_leg = self.class.new(self.class.conditions_for(source, sink))
+          bridging_leg.make_indirect
+          bridging_leg.internal_count = 0
+        end
+        bridging_leg.internal_count = bridging_leg.count + count
+        bridging_leg
+      end
+
+      #Find the edges that need to be updated
+      def wiring
+        source = self.source
+        sink = self.sink
+        above_sources = []
+        self.links_to_source.each do |edge|
+          above_sources << edge.source
+        end
+        below_sinks = []
+        self.links_from_sink.each do |edge|
+          below_sinks << edge.sink
+        end
+        above_bridging_legs = []
+        #everything above me tied to my sink
+        above_sources.each do |above_source|
+          above_leg = self.class.find_link(above_source, source)
+          above_bridging_leg = self.rewire_crossing(above_leg, self)
+          above_bridging_legs << above_bridging_leg unless above_bridging_leg.nil?
+        end
+
+        #everything beneath me tied to my source
+        below_sinks.each do |below_sink|
+          below_leg = self.class.find_link(sink, below_sink)
+          below_bridging_leg = self.rewire_crossing(self, below_leg)
+          self.push_associated_modification!(below_bridging_leg)
+          above_bridging_legs.each do |above_bridging_leg|
+            long_leg = self.rewire_crossing(above_bridging_leg, below_leg)
+            self.push_associated_modification!(long_leg)
+          end
+        end
+        above_bridging_legs.each do |above_bridging_leg|
+          self.push_associated_modification!(above_bridging_leg)
+        end
+      end
+    end
+
+  end
+end

--- a/your_platform/lib/your_platform/dag/edges.rb
+++ b/your_platform/lib/your_platform/dag/edges.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/edges.rb
+#
 module Dag
   module Edges
 

--- a/your_platform/lib/your_platform/dag/poly_columns.rb
+++ b/your_platform/lib/your_platform/dag/poly_columns.rb
@@ -1,0 +1,12 @@
+module Dag
+  #Methods that show the columns for polymorphic DAGs
+  module PolyColumns
+    def ancestor_type_column_name
+      acts_as_dag_options[:ancestor_type_column]
+    end
+
+    def descendant_type_column_name
+      acts_as_dag_options[:descendant_type_column]
+    end
+  end
+end

--- a/your_platform/lib/your_platform/dag/poly_columns.rb
+++ b/your_platform/lib/your_platform/dag/poly_columns.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/poly_columns.rb
+#
 module Dag
   #Methods that show the columns for polymorphic DAGs
   module PolyColumns

--- a/your_platform/lib/your_platform/dag/polymorphic.rb
+++ b/your_platform/lib/your_platform/dag/polymorphic.rb
@@ -1,0 +1,76 @@
+module Dag
+  module Polymorphic
+
+    def self.included(base)
+      base.send :include, PolyEdgeInstanceMethods
+    end
+
+    #Contains nested classes in the link model for polymorphic DAGs
+    #Encapsulates the necessary information about a graph node
+    class EndPoint
+      #Does the endpoint match a model or another endpoint
+      def matches?(other)
+        return (self.id == other.id) && (self.type == other.type) if other.is_a?(EndPoint)
+        (self.id == other.id) && (self.type == other.class.to_s)
+      end
+
+      #Factory Construction method that creates an EndPoint instance from a model
+      def self.from_resource(resource)
+        self.new(resource.id, resource.class.to_s)
+      end
+
+      #Factory Construction method that creates an EndPoint instance from a model if necessary
+      def self.from(obj)
+        return obj if obj.kind_of?(EndPoint)
+        self.from_resource(obj)
+      end
+
+      #Initializes the EndPoint instance with an id and type
+      def initialize(id, type)
+        @id = id
+        @type = type
+      end
+
+      attr_reader :id, :type
+    end
+
+    #Encapsulates information about the source of a link
+    class Source < EndPoint
+      #Factory Construction method that generates a source from a link
+      def self.from_edge(edge)
+        self.new(edge.ancestor_id, edge.ancestor_type)
+      end
+    end
+
+    #Encapsulates information about the sink (destination) of a link
+    class Sink < EndPoint
+      #Factory Construction method that generates a sink from a link
+      def self.from_edge(edge)
+        self.new(edge.descendant_id, edge.descendant_type)
+      end
+    end
+
+    #Contains class methods that extend the link model for polymorphic DAGs
+    #Builds a hash that describes a link from a source and a sink
+    def conditions_for(source, sink)
+      {
+              ancestor_id_column_name => source.id,
+              ancestor_type_column_name => source.type,
+              descendant_id_column_name => sink.id,
+              descendant_type_column_name => sink.type
+      }
+    end
+
+    #Instance methods included into link model for a polymorphic DAG
+    module PolyEdgeInstanceMethods
+      def ancestor_type
+        self[ancestor_type_column_name]
+      end
+
+      def descendant_type
+        self[descendant_type_column_name]
+      end
+    end
+
+  end
+end

--- a/your_platform/lib/your_platform/dag/polymorphic.rb
+++ b/your_platform/lib/your_platform/dag/polymorphic.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/polymorphic.rb
+#
 module Dag
   module Polymorphic
 

--- a/your_platform/lib/your_platform/dag/standard.rb
+++ b/your_platform/lib/your_platform/dag/standard.rb
@@ -1,0 +1,62 @@
+module Dag
+  module Standard
+
+    def self.included(base)
+      base.send :include, NonPolyEdgeInstanceMethods
+    end
+
+    #Encapsulates the necessary information about a graph node
+    class EndPoint
+      #Does an endpoint match another endpoint or model instance
+      def matches?(other)
+        self.id == other.id
+      end
+
+      #Factory Construction method that creates an endpoint from a model
+      def self.from_resource(resource)
+        self.new(resource.id)
+      end
+
+      #Factory Construction method that creates an endpoint from a model if necessary
+      def self.from(obj)
+        return obj if obj.kind_of?(EndPoint)
+        self.from_resource(obj)
+      end
+
+      #Initializes an endpoint based on an Id
+      def initialize(id)
+        @id = id
+      end
+
+      attr_reader :id
+    end
+
+    #Encapsulates information about the source of a link
+    class Source < EndPoint
+      #Factory Construction method creates a source instance from a link
+      def self.from_edge(edge)
+        self.new(edge.ancestor_id)
+      end
+    end
+    #Encapsulates information about the sink of a link
+    class Sink < EndPoint
+      #Factory Construction method creates a sink instance from a link
+      def self.from_edge(edge)
+        self.new(edge.descendant_id)
+      end
+    end
+
+    #Builds a hash that describes a link from a source and a sink
+    def conditions_for(source, sink)
+      {
+              ancestor_id_column_name => source.id,
+              descendant_id_column_name => sink.id
+      }
+    end
+
+    #Instance methods included into the link model for a non-polymorphic DAG
+    module NonPolyEdgeInstanceMethods
+    end
+
+  end
+end

--- a/your_platform/lib/your_platform/dag/standard.rb
+++ b/your_platform/lib/your_platform/dag/standard.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/standard.rb
+#
 module Dag
   module Standard
 

--- a/your_platform/lib/your_platform/dag/validators.rb
+++ b/your_platform/lib/your_platform/dag/validators.rb
@@ -1,0 +1,58 @@
+module Dag
+
+    #Validations on model instance creation. Ensures no duplicate links, no cycles, and correct count and direct attributes
+  class CreateCorrectnessValidator < ActiveModel::Validator
+
+    def validate(record)
+      record.errors[:base] << 'Link already exists between these points' if has_duplicates(record)
+      record.errors[:base] << 'Link already exists in the opposite direction' if has_long_cycles(record)
+      record.errors[:base] << 'Link must start and end in different places' if has_short_cycles(record)
+      cnt = check_possible(record)
+      record.errors[:base] << 'Cannot create a direct link with a count other than 0' if cnt == 1
+      record.errors[:base] << 'Cannot create an indirect link with a count less than 1' if cnt == 2
+    end
+
+    private
+
+    #check for duplicates
+    def has_duplicates(record)
+      record.class.find_link(record.source, record.sink)
+    end
+
+    #check for long cycles
+    def has_long_cycles(record)
+      record.class.find_link(record.sink, record.source)
+    end
+
+    #check for short cycles
+    def has_short_cycles(record)
+      record.sink.matches?(record.source)
+    end
+
+    #check not impossible
+    def check_possible(record)
+      record.direct? ? (record.count != 0 ? 1 : 0) : (record.count < 1 ? 2 : 0)
+    end
+  end
+
+  #Validations on update. Makes sure that something changed, that not making a lonely link indirect, and count is correct.
+  class UpdateCorrectnessValidator < ActiveModel::Validator
+
+    def validate(record)
+      record.errors[:base] << "No changes" unless record.changed?
+      record.errors[:base] << "Do not manually change the count value" if manual_change(record)
+      record.errors[:base] << "Cannot make a direct link with count 1 indirect" if direct_indirect(record)
+    end
+
+    private
+
+    def manual_change(record)
+      record.direct_changed? && record.count_changed?
+    end
+
+    def direct_indirect(record)
+      record.direct_changed? && !record.direct? && record.count == 1
+    end
+  end
+
+end

--- a/your_platform/lib/your_platform/dag/validators.rb
+++ b/your_platform/lib/your_platform/dag/validators.rb
@@ -1,3 +1,6 @@
+# Vendored from acts-as-dag. Corresponding upstream file:
+# https://github.com/resgraph/acts-as-dag/blob/master/lib/dag/validators.rb
+#
 module Dag
 
     #Validations on model instance creation. Ensures no duplicate links, no cycles, and correct count and direct attributes

--- a/your_platform/lib/your_platform/engine.rb
+++ b/your_platform/lib/your_platform/engine.rb
@@ -12,7 +12,7 @@ require 'rails-i18n'
 require 'decent_exposure'
 
 # Data Structures
-require 'acts-as-dag'
+require 'your_platform/dag'
 require 'acts_as_tree'
 require 'wannabe_bool'
 require 'acts-as-taggable-on'

--- a/your_platform/your_platform.gemspec
+++ b/your_platform/your_platform.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 2.3.0'
 
   # Data Structures
-  # DAG Structure, https://github.com/resgraph/acts-as-dag
-  s.add_dependency 'acts-as-dag', '>= 4.0'
+  # The DAG structure lives in lib/your_platform/dag, vendored from
+  # https://github.com/fiedl/acts-as-dag (branch sf/rails-5).
   s.add_dependency 'acts_as_tree'                                                      # MIT License
   s.add_dependency 'wannabe_bool'
   s.add_dependency 'acts-as-taggable-on', '~> 4.0'


### PR DESCRIPTION
Part 2 of https://github.com/fiedl/wingolfsplattform/issues/129, stacked on #130.

The next steps replace the closure-table maintenance of the acts-as-dag gem with recursive CTE queries, piece by piece. That requires editing the DSL, which is not reasonably possible while it lives in a git-pinned gem. Vendored into `your_platform/lib/your_platform/dag/`, every upcoming change to it becomes a reviewable diff.

- `lib/dag/*` copied unchanged from [fiedl/acts-as-dag](https://github.com/fiedl/acts-as-dag), branch `sf/rails-5`, revision 5e185dd, v4.0.0 (838 lines, MIT license included)
- new loader `lib/your_platform/dag.rb` replicates the gem entry point (`ActiveRecord::Base.extend Dag`)
- gem removed from the Gemfile, the gemspec, and the lock

No behavior change; `acts_as_dag_links`, `has_dag_links`, and the `core_ext/acts_as_dag.rb` override work as before.

## Verification

Full suite green locally across the five CI slices (engine models 1633 examples, engine features a–l 113, m–z 150, app models 445, app features 16). One timing-sensitive spec (`membership_validity_range_spec.rb:153`) flaked on first run and passed on the harness rerun; it is untouched by this change.

Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5) — https://claude.ai/code/session_014MocsBNptMjcy3dCkMvucS
