### PR TITLE
Mailing lists: rewrite From to our own domain for DMARC alignment

### DIFF
--- a/your_platform/app/mailers/comment_mailer.rb
+++ b/your_platform/app/mailers/comment_mailer.rb
@@ -35,7 +35,10 @@ class CommentMailer < BaseMailer
 
     message = mail subject: @subject
 
-    message.from = "#{@author.title} <#{@author.email}>"
+    # To pass DMARC checks at the receiving mail servers, the `From:` address
+    # must be on our own email domain. The author moves to `Reply-To:`.
+    # https://github.com/fiedl/wingolfsplattform/issues/125
+    message.from = "\"#{@author.title} via #{AppVersion.app_name}\" <#{Setting.support_email}>"
     message.reply_to = "#{@author.title} <#{@author.email}>"
     message.return_path = BaseMailer.delivery_errors_address
     message.sender = BaseMailer.technical_sender

--- a/your_platform/app/mailers/post_mailer.rb
+++ b/your_platform/app/mailers/post_mailer.rb
@@ -15,20 +15,39 @@ class PostMailer < BaseMailer
 
     message = mail subject: @subject
 
-    message.from = "#{post.author.title} <#{post.author.email}>"
+    # To pass DMARC checks at the receiving mail servers, the `From:` address
+    # must be on our own email domain: DMARC requires SPF or DKIM to validate
+    # for the `From:` domain, and neither can when we send the author's
+    # address through our own SMTP server. The author moves to `Reply-To:`
+    # so that replies still reach them.
+    #
+    # https://github.com/fiedl/wingolfsplattform/issues/125
+    #
+    primary_group = post.parent_groups.first
+    message.from = "\"#{post.author.title} via #{primary_group.name}\" <#{list_address(primary_group)}>"
     message.reply_to = "#{post.author.title} <#{post.author.email}>"
     message.return_path = BaseMailer.delivery_errors_address
     message.sender = BaseMailer.technical_sender
     message.to = post.parent_groups.collect { |group|
-      address = group.mailing_lists.first.try(:value)
-      address ||= "#{group.title.parameterize}-#{group.id}.noreply@#{AppVersion.domain}"
-      "#{group.name_with_corporation} <#{address}>"
+      "#{group.name_with_corporation} <#{list_address(group)}>"
     }.join(", ")
     message.cc = "#{post.author.title} <#{post.author.email}>"
     message.smtp_envelope_to = recipient.email || raise('no delivery address!')
     message.date = post.sent_at
 
+    message['List-Id'] = "\"#{primary_group.name}\" <#{list_address(primary_group).tr('@', '.')}>"
+    message['List-Post'] = "<mailto:#{list_address(primary_group)}>"
+    message['List-Unsubscribe'] = "<mailto:#{Setting.support_email}?subject=unsubscribe%20#{list_address(primary_group)}>"
+    message['Precedence'] = 'list'
+
     return message
+  end
+
+  private
+
+  def list_address(group)
+    group.mailing_lists.first.try(:value) ||
+      "#{group.title.parameterize}-#{group.id}.noreply@#{AppVersion.domain}"
   end
 
 end

--- a/your_platform/app/models/incoming_mails/group_mailing_list_mail.rb
+++ b/your_platform/app/models/incoming_mails/group_mailing_list_mail.rb
@@ -12,6 +12,18 @@ class IncomingMails::GroupMailingListMail < IncomingMail
     end
   end
 
+  # Transport and authentication headers of the original message.
+  # The forwarded copies must not keep them: The original DKIM signature
+  # breaks when we rewrite headers and substitute the greeting placeholders,
+  # and a broken signature scores worse at spam filters than none. The
+  # remaining ones are classic forwarding-spam fingerprints.
+  #
+  STALE_TRANSPORT_HEADERS = %w(
+    DKIM-Signature X-Google-DKIM-Signature
+    ARC-Seal ARC-Message-Signature ARC-Authentication-Results
+    Authentication-Results Received Return-Path Delivered-To X-Original-To
+  )
+
   def deliver_message_to_earch_user_later
     deliveries = recipient_group.members.with_account.collect do |user|
 
@@ -21,17 +33,41 @@ class IncomingMails::GroupMailingListMail < IncomingMail
       # in the loop.
       new_message = Mail::Message.new self.message.to_s
 
+      STALE_TRANSPORT_HEADERS.each { |header| remove_header new_message, header }
+
+      replace_header new_message, 'X-Original-From', sender_string
       new_message.from = formatted_from
-      new_message.reply_to = formatted_from
+      new_message.reply_to = formatted_reply_to
       new_message.return_path = BaseMailer.delivery_errors_address
       new_message.sender = BaseMailer.technical_sender
       new_message.to = formatted_to_field
       new_message.cc = formatted_cc_field
+      replace_header new_message, 'List-Id', "\"#{recipient_group.name}\" <#{list_address.tr('@', '.')}>"
+      replace_header new_message, 'List-Post', "<mailto:#{list_address}>"
+      replace_header new_message, 'List-Unsubscribe', "<mailto:#{Setting.support_email}?subject=unsubscribe%20#{list_address}>"
+      replace_header new_message, 'Precedence', 'list'
       new_message.smtp_envelope_to = user.email
       fill_in_placeholders new_message, from_user: sender_user, to_user: user
       new_message.deliver_with_action_mailer_later
     end
     deliveries
+  end
+
+  # Assigning `nil` removes all occurrences of a header — but only if the
+  # header is present. Otherwise, `Mail::Message#[]=` would add an empty
+  # header field instead.
+  #
+  def remove_header(message, name)
+    message[name] = nil if message[name]
+  end
+
+  # For header fields that are not limited to a single occurrence,
+  # `Mail::Message#[]=` appends rather than replaces. Remove existing
+  # occurrences first, e.g. list headers of an upstream mailing list.
+  #
+  def replace_header(message, name, value)
+    remove_header message, name
+    message[name] = value
   end
 
   def create_post_later
@@ -73,12 +109,52 @@ class IncomingMails::GroupMailingListMail < IncomingMail
     end
   end
 
-  # To meet spam-protection requirements, re-format the "from" field if needed.
+  # To pass DMARC checks at the receiving mail servers, the `From:` address
+  # must be on our own email domain (From-rewriting, as mailman does it):
+  # DMARC requires SPF or DKIM to validate for the `From:` domain, and
+  # neither can when we send the author's address through our own SMTP
+  # server. The author moves to `Reply-To:` so that replies still reach them.
   #
+  # https://github.com/fiedl/wingolfsplattform/issues/125
+  #
+  def formatted_from
+    "\"#{author_display_name} via #{recipient_group.name}\" <#{list_address}>"
+  end
+
+  def author_display_name
+    if sender_user
+      sender_user.title
+    elsif sender_name.present? && sender_name != sender_email
+      sender_name.gsub("\"", "")
+    else
+      sender_email
+    end
+  end
+
+  # The address used in the rewritten `From:` field. It must always be on
+  # our own email domain; a foreign domain would recreate the DMARC
+  # misalignment.
+  #
+  def list_address
+    if on_own_email_domain?(destination)
+      destination
+    else
+      # The message reached us through a foreign-domain alias that forwards
+      # to us (see `IncomingMail#x_original_to`). Use the group's own
+      # list address on our domain instead.
+      own_list = recipient_group.mailing_lists.detect { |field| on_own_email_domain?(field.value) }
+      own_list.try(:value) || "#{recipient_group.title.parameterize}-#{recipient_group.id}.noreply@#{AppVersion.domain}"
+    end
+  end
+
+  def on_own_email_domain?(address)
+    address.to_s.split("@").last.to_s.ends_with? AppVersion.email_domain
+  end
+
   # https://trello.com/c/s94OXzul/1371-e-mails-554-570-reject
   # https://stackoverflow.com/q/57173606/2066546
   #
-  def formatted_from
+  def formatted_reply_to
     if sender_user
       "\"#{sender_user.title}\" <#{sender_email}>"
     else

--- a/your_platform/spec/mailers/comment_mailer_spec.rb
+++ b/your_platform/spec/mailers/comment_mailer_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+# type: :model — the rspec mailer-type setup (ActionMailer::TestCase)
+# clashes with the `content_type` override in core_ext/mail/message.rb.
+describe CommentMailer, type: :model do
+  describe "#comment_email" do
+    let(:group) { create :group, name: "Developers" }
+    let(:author) { create :user_with_account, email: 'john@example.com' }
+    let(:commenter) { create :user_with_account, email: 'jane@example.com' }
+    let(:recipient) { create :user_with_account }
+    let(:post) { group.create_post author_user_id: author.id, subject: "Great news", text: "Free drinks this evening!", sent_at: 1.hour.ago }
+
+    before { post.comments.create author_user_id: commenter.id, text: "Can't wait!" }
+
+    # The production template lives in the private additions repo
+    # (see PrivateViews); the specs bring their own minimal one.
+    before { CommentMailer.prepend_view_path File.expand_path("../../support/views", __FILE__) }
+
+    subject(:message) { CommentMailer.comment_email(post: post, recipient: recipient) }
+
+    # DMARC requires SPF or DKIM to validate for the `From:` domain,
+    # which neither can when we send the author's address through our
+    # own SMTP server. https://github.com/fiedl/wingolfsplattform/issues/125
+    it "sends from our own support address to keep DMARC alignment" do
+      message.from.should == [Setting.support_email]
+      message[:from].to_s.should include "#{commenter.title} via"
+    end
+    it "keeps the comment author as Reply-To" do
+      message.reply_to.should == ['jane@example.com']
+    end
+    it "delivers to the recipient via the smtp envelope" do
+      message.smtp_envelope_to.should == [recipient.email]
+    end
+  end
+end

--- a/your_platform/spec/mailers/post_mailer_spec.rb
+++ b/your_platform/spec/mailers/post_mailer_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+# type: :model — the rspec mailer-type setup (ActionMailer::TestCase)
+# clashes with the `content_type` override in core_ext/mail/message.rb.
+describe PostMailer, type: :model do
+  describe "#post_email" do
+    let(:group) {
+      group = create :group, name: "Developers"
+      group.mailing_lists.create label: "Mailing list", value: "all-developers@example.com"
+      group
+    }
+    let(:author) { create :user_with_account, email: 'john@example.com' }
+    let(:recipient) { create :user_with_account }
+    let(:post) { group.create_post author_user_id: author.id, subject: "Great news", text: "Free drinks this evening!", sent_at: 1.hour.ago }
+
+    subject(:message) { PostMailer.post_email(post: post, recipient: recipient) }
+
+    # DMARC requires SPF or DKIM to validate for the `From:` domain,
+    # which neither can when we send the author's address through our
+    # own SMTP server. https://github.com/fiedl/wingolfsplattform/issues/125
+    it "sends from the group's list address to keep DMARC alignment" do
+      message.from.should == ['all-developers@example.com']
+      message[:from].to_s.should include "#{author.title} via Developers"
+    end
+    it "keeps the author as Reply-To" do
+      message.reply_to.should == ['john@example.com']
+    end
+    it "addresses the group's mailing list" do
+      message.to.should == ['all-developers@example.com']
+    end
+    it "adds the list headers" do
+      message['List-Id'].to_s.should include 'all-developers.example.com'
+      message['List-Post'].to_s.should == '<mailto:all-developers@example.com>'
+      message['List-Unsubscribe'].to_s.should include 'unsubscribe'
+      message['Precedence'].to_s.should == 'list'
+    end
+    it "delivers to the recipient via the smtp envelope" do
+      message.smtp_envelope_to.should == [recipient.email]
+    end
+
+    describe "when the group has no mailing list" do
+      let(:group) { create :group, name: "Developers" }
+      it "falls back to a generated noreply address on our domain" do
+        message.from.first.should include ".noreply@"
+      end
+    end
+  end
+end

--- a/your_platform/spec/models/incoming_mails/group_mailing_list_mail_spec.rb
+++ b/your_platform/spec/models/incoming_mails/group_mailing_list_mail_spec.rb
@@ -48,7 +48,9 @@ describe IncomingMails::GroupMailingListMail do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by 1
         last_email.smtp_envelope_to.should == [@member.email]
         last_email.to.should == ['all-developers@example.com']
-        last_email.from.should == ['john@example.com']
+        last_email.from.should == ['all-developers@example.com'] # DMARC From-rewriting
+        last_email[:from].to_s.should include 'via Developers'
+        last_email.reply_to.should == ['john@example.com']
         last_email.subject.should include 'Great news for all developers!'
         last_email.body.should include 'Free drinks this evening!'
       end
@@ -199,6 +201,10 @@ describe IncomingMails::GroupMailingListMail do
           subject
           last_email.to_s.should include "Dear #{@member.name}!"
           last_email.to_s.should_not include "{{greeting}}"
+        end
+        it "keeps the attachment intact" do
+          subject
+          last_email.attachments.collect(&:filename).should == ['pdf-upload.pdf']
         end
 
         describe "when the message has a text and an html part" do
@@ -665,6 +671,92 @@ describe IncomingMails::GroupMailingListMail do
           subject
           last_email["CC"].to_s.should == Mail::Message.new(example_raw_message)["CC"].to_s
           last_email["CC"].to_s.should_not include "all-developers@example.com"
+        end
+      end
+    end
+
+    # DMARC requires SPF or DKIM to validate for the `From:` domain,
+    # which neither can when we forward the author's address through
+    # our own SMTP server. Therefore, the `From:` field is rewritten
+    # to the list address; the author moves to `Reply-To:`.
+    #
+    # https://github.com/fiedl/wingolfsplattform/issues/125
+    #
+    describe "rewriting headers for DMARC alignment" do
+      before { @group.update! mailing_list_sender_filter: :open }
+
+      it "rewrites the From field to the list address on our own email domain" do
+        subject
+        last_email.from.should == ['all-developers@example.com']
+        last_email[:from].to_s.should include "#{@user.title} via Developers"
+      end
+      it "keeps the author as Reply-To" do
+        subject
+        last_email.reply_to.should == ['john@example.com']
+      end
+      it "keeps the original from line as X-Original-From" do
+        subject
+        last_email['X-Original-From'].to_s.should include 'john@example.com'
+      end
+      it "keeps the Message-ID for threading and deduplication" do
+        subject
+        last_email.message_id.should == '579b28a0a60e2_5ccb3ff56d4319d8918bc@example.com'
+      end
+      it "adds the list headers" do
+        subject
+        last_email['List-Id'].to_s.should include 'all-developers.example.com'
+        last_email['List-Post'].to_s.should == '<mailto:all-developers@example.com>'
+        last_email['List-Unsubscribe'].to_s.should include 'unsubscribe'
+        last_email['Precedence'].to_s.should == 'list'
+      end
+      it "keeps the smtp envelope for delivery-error tracking" do
+        subject
+        last_email.smtp_envelope_to.should == [@member.email]
+        last_email['Return-Path'].to_s.should include BaseMailer.delivery_errors_address
+      end
+
+      describe "when the original message carries transport and authentication headers" do
+        let(:example_raw_message) { %{
+          Received: from mail.example.com by mx.example.com with ESMTP id 12345
+          DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=default; h=from:to:subject; bh=abc; b=def
+          Authentication-Results: mx.example.com; dkim=pass header.d=example.com
+          Delivered-To: all-developers@example.com
+          X-Original-To: all-developers@example.com
+          From: john@example.com
+          To: all-developers@example.com
+          Subject: Great news for all developers!
+          Message-ID: <579b28a0a60e2_5ccb3ff56d4319d8918bc@example.com>
+
+          Free drinks this evening!
+        }.gsub("  ", "") }
+
+        it "strips them from the forwarded copies" do
+          subject
+          last_email['DKIM-Signature'].should be_nil
+          last_email['Authentication-Results'].should be_nil
+          last_email['Received'].should be_nil
+          last_email['Delivered-To'].should be_nil
+          last_email['X-Original-To'].should be_nil
+        end
+      end
+
+      describe "when the message was sent to a foreign-domain alias that forwards to us" do
+        let(:example_raw_message) { %{
+          From: john@example.com
+          To: developers@foreign-association.de
+          X-Original-To: developers@foreign-association.de
+          Subject: Great news for all developers!
+          Message-ID: <579b28a0a60e2_5ccb3ff56d4319d8918bc@example.com>
+
+          Free drinks this evening!
+        }.gsub("  ", "") }
+        before do
+          @group.mailing_lists.create label: "Mailing list", value: "developers@foreign-association.de"
+        end
+
+        it "uses the group's own-domain list address in the From field" do
+          subject
+          last_email.from.should == ['all-developers@example.com']
         end
       end
     end

--- a/your_platform/spec/support/views/comment_mailer/comment_email.html.erb
+++ b/your_platform/spec/support/views/comment_mailer/comment_email.html.erb
@@ -1,0 +1,1 @@
+<p>Test template: the real one lives in the private additions repo (see PrivateViews).</p>


### PR DESCRIPTION
Fixes #125.

Group mailing-list mail was increasingly rejected or spam-foldered because all three delivery paths put the original author's address in `From:` while sending through our own SMTP server — violating DMARC alignment, which most providers strictly enforce by now. See the issue for the full diagnosis and decisions.

## What changed

**`IncomingMails::GroupMailingListMail`** (live raw-forwarding path)
- `From:` is rewritten to `"Author via Group" <list-address>`, where the list address is always on our own email domain: the destination itself if it is on our domain, else the group's own-domain mailing list, else the `noreply` fallback pattern from `PostMailer`. The original from-line survives as `X-Original-From:`, and the author moves to `Reply-To:` so replies keep working.
- Each forwarded copy drops the stale transport/authentication headers of the original message (`DKIM-Signature`, `ARC-*`, `Authentication-Results`, `Received`, `Return-Path`, `Delivered-To`, `X-Original-To`) — the original DKIM signature is broken by our header rewriting and placeholder substitution anyway, and scores worse than none.
- Standard list headers are added: `List-Id`, `List-Post`, `List-Unsubscribe` (mailto: placeholder to the support address, per the issue's decision), `Precedence: list`.
- Fidelity constraint preserved: the raw-forward architecture stays; body, MIME structure and attachments pass through unchanged, and `Message-ID`/`References`/`Date` survive for threading. The smtp envelope is untouched, so both delivery-error mechanisms keep working — and valid recipient addresses no longer get mis-flagged `needs_review` over the *sender's* DMARC policy.

**`PostMailer`** — `From:` uses the first parent group's list address with the same "Author via Group" display name (list-address computation extracted from the `To:` logic); `Reply-To:` stays the author; same list headers added.

**`CommentMailer`** — `From:` becomes `"Author via AppName" <support-address>`; `Reply-To:` stays the author. No list headers, since comment notifications are not list traffic.

## Specs

- Extended `group_mailing_list_mail_spec.rb`: From always on our domain (including the foreign-domain-alias case), Reply-To = author, auth headers stripped, list headers present, Message-ID and attachments preserved, envelope unchanged.
- New `post_mailer_spec.rb` and `comment_mailer_spec.rb` (declared `type: :model` because the rspec mailer-type setup clashes with the `content_type` override in `core_ext/mail/message.rb`; the CommentMailer spec brings a minimal template since the real one lives in the private additions repo).
- `bin/rspec your_platform/spec/models/incoming_mails/group_mailing_list_mail_spec.rb your_platform/spec/mailers`: **59 examples, 0 failures** (7 pending are the pre-existing disabled `create_post` examples).

Noteworthy `mail` 2.6 pitfall found on the way: assigning `nil` to a header only removes it if it exists — otherwise `Mail::Message#[]=` *adds an empty header field*, and for non-unique fields plain assignment appends rather than replaces. Hence the `remove_header`/`replace_header` helpers.

## Ops checklist (outside this repo, from the issue)

- [ ] Verify the MTA DKIM-signs outgoing mail for the email domain (+ corporation subdomains) — worth doing first; From-rewriting removes the misalignment, DKIM signing makes mail authenticated.
- [ ] Verify SPF and DMARC DNS records for the email domain.
- [ ] After deploy: test post to a small list including a Gmail address; expect `spf=pass dkim=pass dmarc=pass` in the receiver's `Authentication-Results`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>