### PR TITLE
Repair the contact page and member data summaries

### DIFF
--- a/your_platform/app/helpers/profile_field_helper.rb
+++ b/your_platform/app/helpers/profile_field_helper.rb
@@ -1,10 +1,12 @@
 module ProfileFieldHelper
 
   def profile_field_li( profile_field, options = {} )
-    # options:
-    #   lock_label: true/false, default: false
-    #   no_remove: true/false, default: false
-    render partial: 'profile_fields/profile_field', locals: {profile_field: profile_field}.merge(options) if profile_field
+    # The server-rendered partial 'profile_fields/profile_field' was
+    # removed with the tabler redesign (55e03fb8f); profile fields
+    # render as vue components now, which bring their own edit
+    # controls. The former options (lock_label, no_remove) are
+    # accepted but obsolete.
+    content_tag :li, editable_profile_field(profile_field), class: "attribute profile_field" if profile_field
   end
 
   def profile_field_lis( profile_fields, options = {} )

--- a/your_platform/spec/features/user_contact_information_spec.rb
+++ b/your_platform/spec/features/user_contact_information_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+feature "User Contact Information Page" do
+  include SessionSteps
+
+  scenario "Viewing the own contact information" do
+    @user = create :user_with_account
+    @user.profile_fields.create type: "ProfileFields::Phone", label: "phone", value: "+49 89 1234-56"
+
+    login @user
+    visit user_contact_information_path(@user)
+
+    page.should have_selector '#contact'
+    # The profile fields render as vue components; without a browser
+    # only the component tags are visible.
+    page.should have_selector 'vue_profile_field', visible: :all
+  end
+end


### PR DESCRIPTION
The contact page (`users/:id/contact`) and the member data summaries have raised *Missing partial profile_fields/_profile_field* since the tabler redesign (55e03fb8f, July 2020) removed the server-rendered partial that `profile_field_li` still referenced.

The helper now renders the vue profile field component (`editable_profile_field`), like the rest of the platform does. The former options `lock_label` / `no_remove` are accepted but obsolete — the vue component brings its own edit controls based on the user's permissions.

Found while clicking through the platform for https://github.com/fiedl/wingolfsplattform/issues/129, but independent of that migration: the page is broken on master, too. A feature spec for the contact page is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MocsBNptMjcy3dCkMvucS