### PR TITLE
Performance: index the dag walks, fix redis blocking, slim the ability build and the cache framework

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,24 +57,24 @@ module AbilityDefinitions
 
     if not read_only_mode?
       can :update, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user)
+        user_is_admin_of?(group)
       end
       can :update, Corporation do |group|
-        group.aktivitas.admins_of_self_and_ancestors.include?(user)
+        user_is_admin_of?(group.aktivitas)
       end
       can :rename, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user) and
+        user_is_admin_of?(group) and
 
         # local admins cannot rename groups with flags or corporations.
         #
         not (group.flags.present? || group.corporation?)
       end
       can :change_internal_token, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user)
+        user_is_admin_of?(group)
       end
       # cannot :change_token, Group
       can :update_memberships, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user) and
+        user_is_admin_of?(group) and
 
         # only global admins are allowed to manage local admins.
         #
@@ -84,7 +84,7 @@ module AbilityDefinitions
       # Administratoren von Gruppen dürfen Untergruppen erstellen.
       #
       can :create_group_for, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user)
+        user_is_admin_of?(group)
       end
 
       # Administratoren einer Aktivitas dürfen ihr Amt weitergeben.
@@ -139,7 +139,7 @@ module AbilityDefinitions
       end
 
       can :destroy, Group do |group|
-        group.admins_of_self_and_ancestors.include?(user) and
+        user_is_admin_of?(group) and
 
         # One can't destroy a group with members.
         group.descendant_users.count == 0 and
@@ -148,8 +148,9 @@ module AbilityDefinitions
         group.flags.count == 0
       end
 
-      can [:read, :update, :change_first_name, :change_alias, :change_status, :create_account_for], User, id: Role.of(user).administrated_users.map(&:id)
-      can :manage, UserAccount, user_id: Role.of(user).administrated_users.map(&:id)
+      administrated_user_ids = Role.of(user).administrated_user_ids
+      can [:read, :update, :change_first_name, :change_alias, :change_status, :create_account_for], User, id: administrated_user_ids
+      can :manage, UserAccount, user_id: administrated_user_ids
       can :update_members, Group do |group|
         can? :update, group
       end
@@ -227,14 +228,11 @@ module AbilityDefinitions
     # Eingeloggte Benutzer können lebende Wingolfiten sehen.
     # Von der eigenen Verbindung darf man alle sehen, also auch Gäste.
     # Den Namen kann man von allen Nutzern sehen.
-    can :read, User, id: User.wingolfiten.alive.pluck(:id)
+    can :read, User, id: readable_wingolfit_ids
     # By member ids rather than a `groups:` hash condition: cancancan
     # would join the former groups association, which is now derived.
     # One query for all readable groups' members together.
-    readable_group_ids = user.corporations.collect { |corporation| corporation.child_groups.where(type: ["Aktivitas", "Philisterschaft"]).or(corporation.child_groups.where(name: ["Gäste", "Hausbewohner"])).pluck(:id) }.flatten
-    readable_subtree_ids = readable_group_ids + Dag::Traversal.descendant_ids(
-      ancestor_type: 'Group', ancestor_ids: readable_group_ids, descendant_type: 'Group')
-    can :read, User, id: Membership.direct.where(ancestor_id: readable_subtree_ids).distinct.pluck(:descendant_id)
+    can :read, User, id: readable_corporation_member_ids
     can [:index, :read_name], User
 
     # For the moment, everybody can view the statistics.
@@ -428,6 +426,40 @@ module AbilityDefinitions
   def rights_for_dummy_users
     super
 
+  end
+
+  private
+
+  # The set of living wingolfiten is the same for every signed-in
+  # user, so all requests share one cache entry instead of plucking
+  # thousands of ids each time. Membership changes delete the entry
+  # (see DagLinkCaching); the ttl covers the remaining inputs, such as
+  # newly recorded deaths.
+  #
+  def readable_wingolfit_ids
+    Rails.cache.fetch("ability/wingolfiten_alive_user_ids", expires_in: 10.minutes) do
+      User.wingolfiten.alive.pluck(:id)
+    end
+  end
+
+  # Users of the same corporations share the same readable-member set.
+  # Computed in three flat queries instead of one query chain per
+  # corporation; membership changes are picked up when the ttl runs
+  # out, which matches the eventual consistency the background cache
+  # renewal provides elsewhere.
+  #
+  def readable_corporation_member_ids
+    corporation_ids = user.corporations.map(&:id).sort
+    return [] if corporation_ids.empty?
+    Rails.cache.fetch(["ability/corporation_member_ids", corporation_ids], expires_in: 10.minutes) do
+      child_group_ids = DagLink.where(direct: true, ancestor_type: 'Group', descendant_type: 'Group',
+        ancestor_id: corporation_ids).select(:descendant_id)
+      readable_group_ids = Group.where(id: child_group_ids, type: ["Aktivitas", "Philisterschaft"])
+        .or(Group.where(id: child_group_ids, name: ["Gäste", "Hausbewohner"])).pluck(:id)
+      readable_subtree_ids = readable_group_ids + Dag::Traversal.descendant_ids(
+        ancestor_type: 'Group', ancestor_ids: readable_group_ids, descendant_type: 'Group')
+      Membership.direct.where(ancestor_id: readable_subtree_ids).distinct.pluck(:descendant_id)
+    end
   end
 
 end

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -25,11 +25,5 @@ class ProfileField
     ]
   end
 
-  if use_caching?
-    def self.cached_profileable_methods_depending_on_profile_fields
-      super + %w(w_nummer)
-    end
-  end
-
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -583,7 +583,8 @@ class User
     cache :fruehere_aktivitaetszahl
     cache :name_affix
     cache :title
-    cache :w_nummer
+    # w_nummer is a single indexed profile-field query -- not worth
+    # the cache maintenance.
     cache :aktiver?
     cache :philister?
     cache :administrated_aktivitates

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,4 +101,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Tag every SQL statement with the controller and action it belongs
+  # to, so slow queries in the postgres log point back to their
+  # request. See https://github.com/fiedl/wingolfsplattform/issues/129
+  config.active_record.query_log_tags_enabled = true
 end

--- a/db/migrate/20260714080000_add_covering_indexes_to_dag_links.rb
+++ b/db/migrate/20260714080000_add_covering_indexes_to_dag_links.rb
@@ -1,0 +1,24 @@
+# Since the materialized closure is gone, every transitive question
+# walks the direct edges recursively (Dag::Traversal). The recursion
+# step joins on one side of the edge and selects the other side, so a
+# covering partial index per direction lets the whole walk run as
+# index-only scans instead of heap fetches. valid_from/valid_to ride
+# along for the membership validity walk.
+#
+class AddCoveringIndexesToDagLinks < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dag_links, [:ancestor_type, :ancestor_id],
+      include: [:descendant_type, :descendant_id, :valid_from, :valid_to],
+      where: "direct",
+      name: "dag_links_direct_walk_down",
+      algorithm: :concurrently
+
+    add_index :dag_links, [:descendant_type, :descendant_id],
+      include: [:ancestor_type, :ancestor_id, :valid_from, :valid_to],
+      where: "direct",
+      name: "dag_links_direct_walk_up",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260711160000) do
+ActiveRecord::Schema.define(version: 20260714080000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,7 +124,9 @@ ActiveRecord::Schema.define(version: 20260711160000) do
     t.datetime "valid_from",      precision: 6
     t.string   "type"
     t.index ["ancestor_id", "ancestor_type", "direct"], name: "dag_ancestor", using: :btree
+    t.index ["ancestor_type", "ancestor_id"], name: "dag_links_direct_walk_down", where: "direct", include: ["descendant_type", "descendant_id", "valid_from", "valid_to"]
     t.index ["descendant_id", "descendant_type"], name: "dag_descendant", using: :btree
+    t.index ["descendant_type", "descendant_id"], name: "dag_links_direct_walk_up", where: "direct", include: ["ancestor_type", "ancestor_id", "valid_from", "valid_to"]
   end
 
   create_table "dag_links_indirect_archive", id: false, force: :cascade do |t|

--- a/your_platform/app/controllers/concerns/current_navable.rb
+++ b/your_platform/app/controllers/concerns/current_navable.rb
@@ -19,13 +19,10 @@ concern :CurrentNavable do
   end
 
   def current_home_page
-    @current_home_page ||= if current_navable && current_navable.respond_to?(:home_page) && current_navable.home_page
-      current_navable.home_page
-    elsif Page.find_by(domain: request.host)
-      Page.find_by(domain: request.host)
-    else
-      Page.root || nil
-    end
+    @current_home_page ||=
+      (current_navable.home_page if current_navable && current_navable.respond_to?(:home_page)) ||
+      Page.find_by(domain: request.host) ||
+      Page.root
   end
 
   # This method sets the currently shown navable object.

--- a/your_platform/app/models/ability.rb
+++ b/your_platform/app/models/ability.rb
@@ -139,6 +139,18 @@ class Ability
     @user
   end
 
+  # Several block rules ask for the same group's admins while one page
+  # renders, and each uncached answer walks the whole ancestor chain.
+  # The ability object lives for a single request, so the answers can
+  # be memoized here.
+  #
+  def user_is_admin_of?(group)
+    @user_is_admin_of ||= {}
+    @user_is_admin_of.fetch(group.id) do
+      @user_is_admin_of[group.id] = group.admins_of_self_and_ancestors.include?(user)
+    end
+  end
+
   def rights_for_beta_testers
     # can :use, :new_menu_feature
     can :use, :tab_view  # this switch is only for user-tabs; group-tabs are for all.
@@ -186,11 +198,12 @@ class Ability
     can :index, Issue
     if not read_only_mode?
       can :manage, Group do |group|
-        group.admins_of_self_and_ancestors.include? user
+        user_is_admin_of?(group)
       end
 
-      can [:update, :change_first_name, :change_alias, :create_account_for, :change_status], User, id: Role.of(user).administrated_users.map(&:id)
-      can :manage, UserAccount, user_id: Role.of(user).administrated_users.map(&:id)
+      administrated_user_ids = Role.of(user).administrated_user_ids
+      can [:update, :change_first_name, :change_alias, :create_account_for, :change_status], User, id: administrated_user_ids
+      can :manage, UserAccount, user_id: administrated_user_ids
 
       can :manage, ProfileField do |profile_field|
         profile_field.profileable.nil? ||  # in order to create profile fields

--- a/your_platform/app/models/concerns/dag_link_caching.rb
+++ b/your_platform/app/models/concerns/dag_link_caching.rb
@@ -7,6 +7,21 @@ concern :DagLinkCaching do
     after_commit :delay_renew_cache_of_dependent_nodes, on: :destroy
   end
 
+  # Of the ancestor groups' caches, a membership change only touches
+  # the ones derived from the member set. Everything else on those
+  # groups -- names, breadcrumbs, map items, role caches -- only
+  # changes with the group structure and keeps its cache.
+  def group_caches_depending_on_memberships
+    [
+      :membership_ids_for_member_list,
+      :memberships_for_member_list_count,
+      :latest_membership_ids,
+      :membership_ids_this_year,
+      :member_table_rows,
+      :fill_cache_for_export_lists
+    ]
+  end
+
   def fill_cache
     super
     ancestor.try(:fill_cache)
@@ -18,12 +33,32 @@ concern :DagLinkCaching do
   # ancestor groups itself: their member lists, exports, and role
   # caches depend on the subtree.
   #
+  # The two changed nodes renew immediately. The fan-out to the
+  # transitive ancestor groups is debounced: bulk operations -- a
+  # semester's status changes, an import -- hit the same ancestor
+  # groups over and over, and one renewal after the wave covers all of
+  # it because the renewal recomputes from the database as it is then.
+  #
   def delay_renew_cache_of_dependent_nodes
-    nodes = [ancestor, descendant] - [nil]
-    if ancestor.kind_of?(Group)
-      nodes += Group.where(id: Dag::Traversal.ancestor_ids_of(ancestor, type: 'Group')).to_a
-    end
-    RenewCacheJob.perform_later records: nodes.uniq, time: Time.zone.now
+    RenewCacheJob.perform_later records: ([ancestor, descendant] - [nil]).uniq, time: Time.zone.now
+    delay_renew_cache_of_ancestor_groups if ancestor.kind_of?(Group)
+  end
+
+  def delay_renew_cache_of_ancestor_groups
+    membership_change = descendant.kind_of?(User)
+    Rails.cache.delete "ability/wingolfiten_alive_user_ids" if membership_change
+
+    scope = membership_change ? "memberships" : "full"
+    groups = Group.where(id: Dag::Traversal.ancestor_ids_of(ancestor, type: 'Group')).to_a.select { |group|
+      Rails.cache.write ["dag-ancestor-renewal-pending", group.id, scope], true,
+        expires_in: 60.seconds, unless_exist: true
+    }
+    return if groups.empty?
+
+    # The renewal time lies at the end of the debounce window, so the
+    # job covers every change that piggybacked onto it.
+    RenewCacheJob.set(wait: 60.seconds).perform_later records: groups, time: 60.seconds.from_now,
+      methods: (group_caches_depending_on_memberships if membership_change)
   end
 
 end

--- a/your_platform/app/models/concerns/profile_field_caching.rb
+++ b/your_platform/app/models/concerns/profile_field_caching.rb
@@ -37,7 +37,9 @@ concern :ProfileFieldCaching do
   class_methods do
 
     def cached_profileable_methods_depending_on_profile_fields
-      %w(date_of_birth date_of_death age birthday_this_year email name_with_surrounding address_label)
+      # Single-field lookups (email, dates, age) are no longer cached
+      # and need no renewal here.
+      %w(name_with_surrounding address_label)
     end
 
   end

--- a/your_platform/app/models/concerns/user_caching.rb
+++ b/your_platform/app/models/concerns/user_caching.rb
@@ -7,7 +7,12 @@ concern :UserCaching do
   included do
     after_save { RenewCacheJob.perform_later(records: self, time: Time.zone.now) }
 
-    cache :date_of_death
+    # Only methods whose recomputation costs clearly more than a cache
+    # round trip are cached: multi-query aggregations and graph
+    # traversals. Single profile-field or flag lookups (email, dates,
+    # gender, hidden) are one indexed query each -- caching them saves
+    # nothing per read but costs an invalidation and a renewal job on
+    # every write, forever.
     cache :name_with_surrounding
     cache :address_label
     cache :current_corporations
@@ -15,30 +20,20 @@ concern :UserCaching do
     cache :my_groups_in_first_corporation
     cache :status_group_in_primary_corporation
     cache :status_export_string
-    cache :hidden
     cache :workflows_by_corporation
-
-    # UserDateOfBirth
-    cache :date_of_birth
-    cache :birthday_this_year
 
     cache :group_ids_by_category
 
     # UserRoles
     cache :admin_of_anything?
     cache :former_member?
-    cache :localized_date_of_org_membership_end
     cache :developer?
     cache :beta_tester?
     cache :global_admin?
     cache :global_officer?
 
     # ProfileFields
-    cache :email
     cache :address_fields_json
-
-    # UserGender
-    cache :female?
   end
 
   # # Aparently, the `StructureableMixins::Roles` don't work correctly

--- a/your_platform/app/models/group.rb
+++ b/your_platform/app/models/group.rb
@@ -199,10 +199,22 @@ class Group < ApplicationRecord
   def leaf_groups
     Group.find(leaf_group_ids)
   end
+  # Flat queries instead of asking every descendant group for its
+  # subgroups and ancestors one by one: one traversal for the subtree,
+  # one query for the direct links within it, and one traversal for
+  # the officer subtrees.
+  #
   def leaf_group_ids
-    self.descendant_groups.order('id').includes(:flags).select { |group|
-      group.has_no_subgroups_other_than_the_officers_parent? and not group.is_officers_group?
-    }.map(&:id).uniq
+    ids = Dag::Traversal.descendant_ids_of(self, type: 'Group')
+    return [] if ids.empty?
+    links = DagLink.where(direct: true, ancestor_type: 'Group', descendant_type: 'Group',
+      ancestor_id: ids).pluck(:ancestor_id, :descendant_id)
+    officer_named_ids = Group.where(id: links.collect(&:last).uniq, name: ["Amtsträger", "officers"]).pluck(:id).to_set
+    ids_with_real_subgroups = links.reject { |_, child_id| officer_named_ids.include?(child_id) }.collect(&:first).to_set
+    officers_parent_ids = Group.where(id: ids + [id]).flagged(:officers_parent).pluck(:id)
+    officer_group_ids = Dag::Traversal.descendant_ids(ancestor_type: 'Group', descendant_type: 'Group',
+      ancestor_ids: officers_parent_ids).to_set
+    ids.sort.select { |group_id| !ids_with_real_subgroups.include?(group_id) && !officer_group_ids.include?(group_id) }
   end
 
   def status_groups
@@ -222,10 +234,16 @@ class Group < ApplicationRecord
     end
   end
   def status_group_tree_ids
-    child_groups_with_status_groups.collect { |child_group| [child_group, child_group.descendant_groups] }.flatten.map(&:id)
+    ids = child_groups_with_status_groups.map(&:id)
+    ids + Dag::Traversal.descendant_ids(ancestor_type: 'Group', descendant_type: 'Group', ancestor_ids: ids)
   end
+  # One traversal for the ancestors of all status groups together
+  # rather than one traversal per status group.
   def child_groups_with_status_groups
-    child_groups & (status_groups + status_groups.map(&:ancestor_groups)).flatten
+    ids = status_group_ids
+    keep = (ids + Dag::Traversal.ancestor_ids(descendant_type: 'Group', ancestor_type: 'Group',
+      descendant_ids: ids)).to_set
+    child_groups.select { |child_group| keep.include?(child_group.id) }
   end
   def status_groups_with_level(group_hash_array = status_group_tree, level = 0)
     group_hash_array.collect do |entry|

--- a/your_platform/app/models/role.rb
+++ b/your_platform/app/models/role.rb
@@ -168,6 +168,14 @@ class Role
     directly_administrated_groups.collect { |g| g.descendant_users }.flatten
   end
 
+  # For authorization rules that only need the ids: one recursive
+  # query instead of instantiating every administrated user.
+  #
+  def administrated_user_ids
+    Dag::Traversal.descendant_ids ancestor_type: 'Group', descendant_type: 'User',
+      ancestor_ids: directly_administrated_groups.collect(&:id)
+  end
+
 
   # This finder method returns all global admins.
   #

--- a/your_platform/core_ext/active_support/cache.rb
+++ b/your_platform/core_ext/active_support/cache.rb
@@ -111,8 +111,7 @@ module CacheStoreExtension
   end
 
   def delete_regex(regex)
-    keys = raw_keys_by_regex(regex)
-    redis.del(*keys) if keys.count > 0
+    raw_keys_by_regex(regex).each_slice(1000) { |keys| redis.del(*keys) }
   end
 
   # Logical keys (without the namespace prefix), matching the regex.
@@ -123,10 +122,15 @@ module CacheStoreExtension
     raw_keys_by_regex(regex).collect { |raw_key| raw_key.delete_prefix(namespace_prefix) }
   end
 
+  # SCAN rather than KEYS: KEYS walks the whole keyspace in one
+  # blocking call and freezes the redis server for every other cache
+  # read while it runs.
   def raw_keys_by_regex(regex)
     return [] unless respond_to? :redis
     prefix = namespace_prefix
-    redis.keys.select { |raw_key| raw_key.delete_prefix(prefix) =~ regex }
+    keys = []
+    redis.scan_each { |raw_key| keys << raw_key if raw_key.delete_prefix(prefix) =~ regex }
+    keys
   end
   private :raw_keys_by_regex
 

--- a/your_platform/spec/models/user_spec.rb
+++ b/your_platform/spec/models/user_spec.rb
@@ -921,8 +921,11 @@ describe User do
     before do
       @corporation1 = create :corporation_with_status_groups
       @corporation2 = create :corporation_with_status_groups
-      @corporation1.status_groups.first.assign_user @user
-      @corporation1.status_groups.last.assign_user @user
+      # Ordered explicitly: neither status_groups nor user.groups
+      # guarantees an order, so first/last would name arbitrary groups.
+      @status_groups = @corporation1.status_groups.order(:id).to_a
+      @status_groups.first.assign_user @user
+      @status_groups.last.assign_user @user
       @corporation2.status_groups.first.assign_user @user
       @corporation1.assign_admin @user
       time_travel 5.seconds
@@ -930,7 +933,7 @@ describe User do
     end
     subject { @user.my_groups_in_first_corporation }
     it "should return the non special groups of user's first corporation" do
-      subject.should == [ @corporation1.status_groups.first, @corporation1.status_groups.last ]
+      subject.should match_array [ @status_groups.first, @status_groups.last ]
     end
   end
 


### PR DESCRIPTION
## Why

Despite years of caching effort, the platform chronically felt slow. A code analysis found the load-bearing causes elsewhere than expected: the authorization build materialized the whole organization's user ids on every request (twice), bulk cache deletion blocked the redis server with `KEYS`, membership changes fanned out into full cache renewals of all transitive ancestor groups, and the recursive CTE traversal introduced with the closure deletion (#129) had no matching indexes.

At the actual data scale (~6.3k users, ~52k direct dag edges) the graph fits in postgres shared buffers — recursive CTEs with covering indexes run in milliseconds, and many cached values were cheaper to recompute than to maintain.

## What

Each commit stands alone:

1. **Covering partial indexes for the recursive dag walks** — one per direction, `INCLUDE`-ing the output columns and validity range, `WHERE direct`. Every CTE recursion step becomes an index-only scan (benefits abilities, member lists, breadcrumbs, group trees). Applied with `algorithm: :concurrently`.
2. **`SCAN` instead of `KEYS`** in `delete_regex`/`find_keys_by_regex` — bulk cache deletions no longer freeze the redis server for every other cache read; deletions are chunked.
3. **Group tree methods as flat queries** — `leaf_group_ids` and `child_groups_with_status_groups` no longer run one query/traversal per descendant or status group.
4. **Debounced, narrowed ancestor-group renewal** — a membership change renews only the member-list/export caches of ancestor groups (not names, breadcrumbs, map items, role caches), and bulk waves collapse into one renewal per group per 60s window, timed at the end of the window so it covers every piggybacked change.
5. **Ability build without whole-org materialization** — the living-wingolfiten id list (identical for every signed-in user) and the per-corporation-set readable-member ids become shared cache entries (10 min ttl; membership changes delete the wingolfiten entry). `Role#administrated_user_ids` answers with one recursive query instead of instantiating every administrated user twice. Repeated `admins_of_self_and_ancestors` block checks are memoized on the ability object. All rules stay `id: <Array>` hash conditions, so `accessible_by` semantics are unchanged.
6. **Stop caching values cheaper than the cache round trip** — email, dates, gender, hidden, w_nummer and friends are one indexed query each; caching them saved nothing per read but cost an invalidation and a renewal job on every write. (`birthday_this_year` was also stale after new year for up to the ttl.) Multi-query aggregations like `aktivitaetszahl` and the role traversals stay cached.
7. **`current_home_page`** — one `Page.find_by(domain:)` lookup per request instead of up to three.
8. **Query log tags in production** — slow statements in the postgres log now name their controller/action. (To use it, set `log_min_duration_statement` ≈ 250ms on the production postgres.)

## Verification

- 785 spec examples green across the affected areas: `spec/models/ability_spec.rb`, `your_platform/spec/models/ability_spec.rb`, `your_platform/spec/models/dag/`, `dag_link_spec.rb`, group/status-group/membership specs, both user specs, `hidden_user_spec.rb`, `profile_field_spec.rb`, and `concerns/caching_spec.rb`.
- One spec (`User#my_groups_in_first_corporation`) asserted the arbitrary row order of the unordered `user.groups` relation, which the new index access path changes — it now orders explicitly and compares order-independently.
- `Role#administrated_user_ids` verified equivalent to `administrated_users.map(&:id)`: the generated `descendant_users` accessor uses the same unfiltered structural traversal SQL.
- Migration applied against the test database; `db/schema.rb` updated by hand in its existing format to avoid a full re-dump.

## Trade-offs and follow-ups

- The ability id lists accept ≤10 min staleness (matching the eventual consistency the async cache renewal already provides elsewhere); membership changes invalidate the global list immediately.
- Deliberately **not** included: deleting `RenewCacheJob`, the renew rake tasks, and the `ActiveSupport::Cache` core extension entirely. That deeper dismantling should wait until the query-log observability from this PR confirms where production time still goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)